### PR TITLE
Robin Hood Hashing

### DIFF
--- a/hppc-core/src/main/templates/com/carrotsearch/hppc/KTypeVTypeRobinHoodHashMap.java
+++ b/hppc-core/src/main/templates/com/carrotsearch/hppc/KTypeVTypeRobinHoodHashMap.java
@@ -1,0 +1,1357 @@
+package com.carrotsearch.hppc;
+
+import java.util.*;
+
+import com.carrotsearch.hppc.cursors.*;
+import com.carrotsearch.hppc.hash.MurmurHash3;
+import com.carrotsearch.hppc.predicates.*;
+import com.carrotsearch.hppc.procedures.*;
+
+import static com.carrotsearch.hppc.Internals.*;
+import static com.carrotsearch.hppc.HashContainerUtils.*;
+
+/**
+ * A hash map of <code>KType</code> to <code>VType</code>, implemented using open
+ * addressing with linear probing for collision resolution.
+ *
+ * <p>
+ * The internal buffers of this implementation ({@link #keys}, {@link #values},
+ * {@link #allocated}) are always allocated to the nearest size that is a power of two. When
+ * the capacity exceeds the given load factor, the buffer size is doubled.
+ * </p>
+ *
+ #if ($TemplateOptions.AllGeneric)
+ * <p>
+ * A brief comparison of the API against the Java Collections framework:
+ * </p>
+ * <table class="nice" summary="Java Collections HashMap and HPPC ObjectObjectOpenHashMap, related methods.">
+ * <caption>Java Collections HashMap and HPPC {@link ObjectObjectOpenHashMap}, related methods.</caption>
+ * <thead>
+ *     <tr class="odd">
+ *         <th scope="col">{@linkplain HashMap java.util.HashMap}</th>
+ *         <th scope="col">{@link ObjectObjectOpenHashMap}</th>  
+ *     </tr>
+ * </thead>
+ * <tbody>
+ * <tr            ><td>V put(K)       </td><td>V put(K)      </td></tr>
+ * <tr class="odd"><td>V get(K)       </td><td>V get(K)      </td></tr>
+ * <tr            ><td>V remove(K)    </td><td>V remove(K)   </td></tr>
+ * <tr class="odd"><td>size, clear, 
+ *                     isEmpty</td><td>size, clear, isEmpty</td></tr>                     
+ * <tr            ><td>containsKey(K) </td><td>containsKey(K), lget()</td></tr>
+ * <tr class="odd"><td>containsValue(K) </td><td>(no efficient equivalent)</td></tr>
+ * <tr            ><td>keySet, entrySet </td><td>{@linkplain #iterator() iterator} over map entries,
+ *                                               keySet, pseudo-closures</td></tr>
+ * </tbody>
+ * </table>
+ #else
+ * <p>See {@link ObjectObjectOpenHashMap} class for API similarities and differences against Java
+ * Collections.  
+ #end
+ *
+ #if ($TemplateOptions.KTypeGeneric)
+ * <p>This implementation supports <code>null</code> keys.</p>
+ #end
+ #if ($TemplateOptions.VTypeGeneric)
+ * <p>This implementation supports <code>null</code> values.</p>
+ #end
+ *
+ * <p><b>Important node.</b> The implementation uses power-of-two tables and linear
+ * probing, which may cause poor performance (many collisions) if hash values are
+ * not properly distributed. This implementation uses rehashing 
+ * using {@link MurmurHash3}.</p>
+ *
+ * @author This code is inspired by the collaboration and implementation in the <a
+ *         href="http://fastutil.dsi.unimi.it/">fastutil</a> project.
+ */
+/*! ${TemplateOptions.generatedAnnotation} !*/
+public class KTypeVTypeRobinHoodHashMap<KType, VType>
+        implements KTypeVTypeMap<KType, VType>, Cloneable
+{
+    /**
+     * Minimum capacity for the map.
+     */
+    public final static int MIN_CAPACITY = HashContainerUtils.MIN_CAPACITY;
+
+    /**
+     * Default capacity.
+     */
+    public final static int DEFAULT_CAPACITY = HashContainerUtils.DEFAULT_CAPACITY;
+
+    /**
+     * Default load factor.
+     */
+    public final static float DEFAULT_LOAD_FACTOR = HashContainerUtils.DEFAULT_LOAD_FACTOR;
+
+    /**
+     * Hash-indexed array holding all keys.
+     *
+     #if ($TemplateOptions.KTypeGeneric)
+     * <p><strong>Important!</strong> 
+     * The actual value in this field is always an instance of <code>Object[]</code>.
+     * Be warned that <code>javac</code> emits additional casts when <code>keys</code> 
+     * are directly accessed; <strong>these casts
+     * may result in exceptions at runtime</strong>. A workaround is to cast directly to
+     * <code>Object[]</code> before accessing the buffer's elements (although it is highly
+     * recommended to use a {@link #iterator()} instead.
+     * </pre>
+     #end
+     *
+     * @see #values
+     */
+    public KType [] keys;
+
+    /**
+     * Hash-indexed array holding all values associated to the keys
+     * stored in {@link #keys}.
+     *
+     #if ($TemplateOptions.KTypeGeneric)
+     * <p><strong>Important!</strong> 
+     * The actual value in this field is always an instance of <code>Object[]</code>.
+     * Be warned that <code>javac</code> emits additional casts when <code>values</code> 
+     * are directly accessed; <strong>these casts
+     * may result in exceptions at runtime</strong>. A workaround is to cast directly to
+     * <code>Object[]</code> before accessing the buffer's elements (although it is highly
+     * recommended to use a {@link #iterator()} instead.
+     * </pre>
+     #end
+     *
+     * @see #keys
+     */
+    public VType [] values;
+
+    /**
+     * Information if an entry (slot) in the {@link #values} table is allocated, or has been tombstoned.
+     * or empty.
+     *
+     * @see #assigned
+     */
+    public boolean [] allocated;
+
+    /**
+     * Cached number of assigned slots in {@link #allocated}.
+     */
+    public int assigned;
+
+    /**
+     * The load factor for this map (fraction of allocated slots
+     * before the buffers must be rehashed or reallocated).
+     */
+    public final float loadFactor;
+
+    /**
+     * Resize buffers when {@link #allocated} hits this value. 
+     */
+    protected int resizeAt;
+
+    /**
+     * The most recent slot accessed in {@link #containsKey} (required for
+     * {@link #lget}).
+     *
+     * @see #containsKey
+     * @see #lget
+     */
+    protected int lastSlot;
+
+    /**
+     * We perturb hashed values with the array size to avoid problems with
+     * nearly-sorted-by-hash values on iterations.
+     *
+     * @see "http://issues.carrot2.org/browse/HPPC-80"
+     */
+    protected int perturbation;
+
+    /**
+     * Creates a hash map with the default capacity of {@value #DEFAULT_CAPACITY},
+     * load factor of {@value #DEFAULT_LOAD_FACTOR}.
+     *
+     * <p>See class notes about hash distribution importance.</p>
+     */
+    public KTypeVTypeRobinHoodHashMap()
+    {
+        this(DEFAULT_CAPACITY);
+    }
+
+    /**
+     * Creates a hash map with the given initial capacity, default load factor of
+     * {@value #DEFAULT_LOAD_FACTOR}.
+     *
+     * <p>See class notes about hash distribution importance.</p>
+     *
+     * @param initialCapacity Initial capacity (greater than zero and automatically
+     *            rounded to the next power of two).
+     */
+    public KTypeVTypeRobinHoodHashMap(int initialCapacity)
+    {
+        this(initialCapacity, DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Creates a hash map with the given initial capacity,
+     * load factor.
+     *
+     * <p>See class notes about hash distribution importance.</p>
+     *
+     * @param initialCapacity Initial capacity (greater than zero and automatically
+     *            rounded to the next power of two).
+     *
+     * @param loadFactor The load factor (greater than zero and smaller than 1).
+     */
+    public KTypeVTypeRobinHoodHashMap(int initialCapacity, float loadFactor)
+    {
+        initialCapacity = Math.max(initialCapacity, MIN_CAPACITY);
+
+        assert initialCapacity > 0
+                : "Initial capacity must be between (0, " + Integer.MAX_VALUE + "].";
+        assert loadFactor > 0 && loadFactor <= 1
+                : "Load factor must be between (0, 1].";
+
+        this.loadFactor = loadFactor;
+        allocateBuffers(roundCapacity(initialCapacity));
+    }
+
+    /**
+     * Create a hash map from all key-value pairs of another container.
+     */
+    public KTypeVTypeRobinHoodHashMap(KTypeVTypeAssociativeContainer<KType, VType> container)
+    {
+        this((int)(container.size() * (1 + DEFAULT_LOAD_FACTOR)));
+        putAll(container);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public VType put(KType key, VType value)
+    {
+        assert assigned < allocated.length;
+        final int mask = allocated.length - 1;
+        int slot = rehash(key, perturbation) & mask;
+        int dist = 0;
+        while (allocated[slot])
+        {
+            int existing_distance = probe_distance(slot);
+            if (Intrinsics.equalsKType(key, keys[slot]))
+            {
+                final VType oldValue = values[slot];
+                values[slot] = value;
+                return oldValue;
+            }
+            else if (dist > existing_distance)
+            {
+                key = swapKey(slot, key);
+                value = swapValue(slot, value);
+                dist = existing_distance;
+            }
+
+            slot = (slot + 1) & mask;
+            dist++;
+        }
+
+        // Check if we need to grow. If so, reallocate new data, fill in the last element 
+        // and rehash.
+        if (assigned == resizeAt) {
+            expandAndPut(key, value, slot);
+        } else {
+            assigned++;
+            allocated[slot] = true;
+            keys[slot] = key;
+            values[slot] = value;
+        }
+        return Intrinsics.<VType> defaultVTypeValue();
+    }
+
+    protected int probe_distance(int slot) {
+        final int mask = allocated.length - 1;
+        int rh = rehash(keys[slot], perturbation) & mask;
+        if (slot < rh) {
+            //wrap around
+            return slot + allocated.length - rh;
+        } else {
+            return slot - rh;
+        }
+    }
+
+    protected KType swapKey(int slot, KType key) {
+        KType tmpKey = keys[slot];
+        keys[slot] = key;
+        return tmpKey;
+    }
+
+    protected VType swapValue(int slot, VType value) {
+        VType tmpValue = values[slot];
+        values[slot] = value;
+        return tmpValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int putAll(
+            KTypeVTypeAssociativeContainer<? extends KType, ? extends VType> container)
+    {
+        final int count = this.assigned;
+        for (KTypeVTypeCursor<? extends KType, ? extends VType> c : container)
+        {
+            put(c.key, c.value);
+        }
+        return this.assigned - count;
+    }
+
+    /**
+     * Puts all key/value pairs from a given iterable into this map.
+     */
+    @Override
+    public int putAll(
+            Iterable<? extends KTypeVTypeCursor<? extends KType, ? extends VType>> iterable)
+    {
+        final int count = this.assigned;
+        for (KTypeVTypeCursor<? extends KType, ? extends VType> c : iterable)
+        {
+            put(c.key, c.value);
+        }
+        return this.assigned - count;
+    }
+
+    /**
+     * <a href="http://trove4j.sourceforge.net">Trove</a>-inspired API method. An equivalent
+     * of the following code:
+     * <pre>
+     * if (!map.containsKey(key)) map.put(value);
+     * </pre>
+     *
+     * <p>This method saves to {@link #lastSlot} as a side effect of each call.</p>
+     *
+     * @param key The key of the value to check.
+     * @param value The value to put if <code>key</code> does not exist.
+     * @return <code>true</code> if <code>key</code> did not exist and <code>value</code>
+     * was placed in the map.
+     */
+    public boolean putIfAbsent(KType key, VType value)
+    {
+        if (!containsKey(key))
+        {
+            put(key, value);
+            return true;
+        }
+        return false;
+    }
+
+    /*! #if ($TemplateOptions.VTypePrimitive) !*/
+    /**
+     * <a href="http://trove4j.sourceforge.net">Trove</a>-inspired API method. A logical 
+     * equivalent of the following code (but does not update {@link #lastSlot):
+     * <pre>
+     *  if (containsKey(key))
+     *  {
+     *      VType v = (VType) (lget() + additionValue);
+     *      lset(v);
+     *      return v;
+     *  }
+     *  else
+     *  {
+     *     put(key, putValue);
+     *     return putValue;
+     *  }
+     * </pre>
+     *
+     * @param key The key of the value to adjust.
+     * @param putValue The value to put if <code>key</code> does not exist.
+     * @param additionValue The value to add to the existing value if <code>key</code> exists.
+     * @return Returns the current value associated with <code>key</code> (after changes).
+     */
+    /*! #end !*/
+    /*! #if ($TemplateOptions.VTypePrimitive) 
+    public VType putOrAdd(KType key, VType putValue, VType additionValue)
+    {
+        assert assigned < allocated.length;
+
+        final int mask = allocated.length - 1;
+        int slot = rehash(key, perturbation) & mask;
+        int dist = 0;
+        while (allocated[slot])
+        {
+            int existing_distance = probe_distance(slot);
+            if (Intrinsics.equalsKType(key, keys[slot]))
+            {
+                return values[slot] = (VType) (values[slot] + additionValue);
+            }
+            else if (dist > existing_distance)
+            {
+                key = swapKey(slot, key);
+                putValue = swapValue(slot, putValue);
+                dist = existing_distance;
+            }
+
+            slot = (slot + 1) & mask;
+            dist++;
+        }
+
+        if (assigned == resizeAt) {
+            expandAndPut(key, putValue, slot);
+        } else {
+            assigned++;
+            allocated[slot] = true;
+            keys[slot] = key;                
+            values[slot] = putValue;
+        }
+        return putValue;
+    }
+    #end !*/
+
+    /*! #if ($TemplateOptions.VTypePrimitive) !*/
+    /**
+     * An equivalent of calling
+     * <pre>
+     *  if (containsKey(key))
+     *  {
+     *      VType v = (VType) (lget() + additionValue);
+     *      lset(v);
+     *      return v;
+     *  }
+     *  else
+     *  {
+     *     put(key, additionValue);
+     *     return additionValue;
+     *  }
+     * </pre>
+     *
+     * @param key The key of the value to adjust.
+     * @param additionValue The value to put or add to the existing value if <code>key</code> exists.
+     * @return Returns the current value associated with <code>key</code> (after changes).
+     */
+    /*! #end !*/
+    /*! #if ($TemplateOptions.VTypePrimitive) 
+    public VType addTo(KType key, VType additionValue)
+    {
+        return putOrAdd(key, additionValue, additionValue);
+    }
+    #end !*/
+
+    /**
+     * Expand the internal storage buffers (capacity) and rehash.
+     */
+    private void expandAndPut(KType pendingKey, VType pendingValue, int freeSlot)
+    {
+        assert assigned == resizeAt;
+        assert !allocated[freeSlot];
+
+        // Try to allocate new buffers first. If we OOM, it'll be now without
+        // leaving the data structure in an inconsistent state.
+        final KType   [] oldKeys      = this.keys;
+        final VType   [] oldValues    = this.values;
+        final boolean    [] oldAllocated = this.allocated;
+
+        allocateBuffers(nextCapacity(keys.length));
+
+        // We have succeeded at allocating new data so insert the pending key/value at
+        // the free slot in the old arrays before rehashing.
+        lastSlot = -1;
+        assigned++;
+        oldAllocated[freeSlot] = true;
+        oldKeys[freeSlot] = pendingKey;
+        oldValues[freeSlot] = pendingValue;
+
+        // Rehash all stored keys into the new buffers.
+        final KType []   keys = this.keys;
+        final VType []   values = this.values;
+        final boolean[]  allocated = this.allocated;
+        final int mask = allocated.length - 1;
+        for (int i = oldAllocated.length; --i >= 0;)
+        {
+            if (oldAllocated[i])
+            {
+                KType k = oldKeys[i];
+                VType v = oldValues[i];
+
+                int slot = rehash(k, perturbation) & mask;
+                int dist = 0;
+                while (allocated[slot])
+                {
+                    int existing_distance = probe_distance(slot);
+                    if (dist > existing_distance)
+                    {
+                        k = swapKey(slot, k);
+                        v = swapValue(slot, v);
+                        dist = existing_distance;
+                    }
+                    slot = (slot + 1) & mask;
+                    dist++;
+                }
+
+                allocated[slot] = true;
+                keys[slot] = k;
+                values[slot] = v;
+            }
+        }
+
+        /* #if ($TemplateOptions.KTypeGeneric) */ Arrays.fill(oldKeys,   null); /* #end */
+        /* #if ($TemplateOptions.VTypeGeneric) */ Arrays.fill(oldValues, null); /* #end */
+    }
+
+    /**
+     * Allocate internal buffers for a given capacity.
+     *
+     * @param capacity New capacity (must be a power of two).
+     */
+    private void allocateBuffers(int capacity)
+    {
+        KType [] keys = Intrinsics.newKTypeArray(capacity);
+        VType [] values = Intrinsics.newVTypeArray(capacity);
+        boolean [] allocated = new boolean [capacity];
+
+        this.keys = keys;
+        this.values = values;
+        this.allocated = allocated;
+
+        this.resizeAt = Math.max(2, (int) Math.ceil(capacity * loadFactor)) - 1;
+        this.perturbation = computePerturbationValue(capacity);
+    }
+
+    /**
+     * <p>Compute the key perturbation value applied before hashing. The returned value
+     * should be non-zero and ideally different for each capacity. This matters because
+     * keys are nearly-ordered by their hashed values so when adding one container's
+     * values to the other, the number of collisions can skyrocket into the worst case
+     * possible.
+     *
+     * <p>If it is known that hash containers will not be added to each other 
+     * (will be used for counting only, for example) then some speed can be gained by 
+     * not perturbing keys before hashing and returning a value of zero for all possible
+     * capacities. The speed gain is a result of faster rehash operation (keys are mostly
+     * in order).   
+     */
+    protected int computePerturbationValue(int capacity)
+    {
+        return PERTURBATIONS[Integer.numberOfLeadingZeros(capacity)];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public VType remove(KType key)
+    {
+        int slot = lookupSlot(key);
+        if (slot == -1)
+        {
+            return Intrinsics.<VType>defaultVTypeValue();
+        }
+        else
+        {
+            VType value = values[slot];
+            shiftConflictingKeys(slot);
+            assigned--;
+            return value;
+        }
+    }
+
+    /**
+     * Shift all the slot-conflicting keys allocated to (and including) <code>slot</code>.
+     */
+    protected void shiftConflictingKeys(int slotCurr)
+    {
+        // Copied nearly verbatim from fastutil's impl.
+        final int mask = allocated.length - 1;
+        int slotPrev, slotOther;
+        while (true)
+        {
+            slotCurr = ((slotPrev = slotCurr) + 1) & mask;
+
+            while (allocated[slotCurr])
+            {
+                slotOther = rehash(keys[slotCurr], perturbation) & mask;
+                if (slotPrev <= slotCurr)
+                {
+                    // we're on the right of the original slot.
+                    if (slotPrev >= slotOther || slotOther > slotCurr)
+                        break;
+                }
+                else
+                {
+                    // we've wrapped around.
+                    if (slotPrev >= slotOther && slotOther > slotCurr)
+                        break;
+                }
+                slotCurr = (slotCurr + 1) & mask;
+            }
+
+            if (!allocated[slotCurr])
+                break;
+
+            // Shift key/value pair.
+            keys[slotPrev] = keys[slotCurr];
+            values[slotPrev] = values[slotCurr];
+        }
+
+        allocated[slotPrev] = false;
+
+        /* #if ($TemplateOptions.KTypeGeneric) */
+        keys[slotPrev] = Intrinsics.<KType> defaultKTypeValue();
+        /* #end */
+        /* #if ($TemplateOptions.VTypeGeneric) */
+        values[slotPrev] = Intrinsics.<VType> defaultVTypeValue();
+        /* #end */
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int removeAll(KTypeContainer<? extends KType> container)
+    {
+        final int before = this.assigned;
+
+        for (KTypeCursor<? extends KType> cursor : container)
+        {
+            remove(cursor.value);
+        }
+
+        return before - this.assigned;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int removeAll(KTypePredicate<? super KType> predicate)
+    {
+        final int before = this.assigned;
+
+        final KType [] keys = this.keys;
+        final boolean [] states = this.allocated;
+
+        for (int i = 0; i < states.length;)
+        {
+            if (states[i])
+            {
+                if (predicate.apply(keys[i]))
+                {
+                    assigned--;
+                    shiftConflictingKeys(i);
+                }
+            }
+            i++;
+        }
+        return before - this.assigned;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Use the following snippet of code to check for key existence
+     * first and then retrieve the value if it exists.</p>
+     * <pre>
+     * if (map.containsKey(key))
+     *   value = map.lget(); 
+     * </pre>
+     * <p>The above code <strong>cannot</strong> be used by multiple concurrent
+     * threads because a call to {@link #containsKey(Object)} stores
+     * the temporary slot number in {@link #lastSlot}. An alternative to the above
+     * conditional statement is to use {@link #getOrDefault(Object, Object)} and
+     * provide a custom default value sentinel (not present in the value set).</p>
+     */
+    @Override
+    public VType get(KType key)
+    {
+        // Same as:
+        // getOrDefault(key, Intrinsics.<VType> defaultVTypeValue())
+        // but let's keep it duplicated for VMs that don't have advanced inlining.
+        int slot = lookupSlot(key);
+        if (slot == -1)
+        {
+            return Intrinsics.<VType>defaultVTypeValue();
+        }
+        else
+        {
+            return values[slot];
+        }
+    }
+
+    protected int lookupSlot(final KType key) {
+        final int mask = allocated.length - 1;
+        int slot = rehash(key, perturbation) & mask;
+        int dist = 0;
+        while (true)
+        {
+            if (!allocated[slot])
+            {
+                return -1;
+            }
+            if (dist > probe_distance(slot))
+            {
+                return -1;
+            }
+            else if (Intrinsics.equalsKType(key, keys[slot]))
+            {
+                return slot;
+            }
+            slot = (slot+1) & mask;
+            dist++;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public VType getOrDefault(KType key, VType defaultValue)
+    {
+        int slot = lookupSlot(key);
+        if (slot == -1)
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return values[slot];
+        }
+    }
+
+    /* #if ($TemplateOptions.KTypeGeneric) */
+    /**
+     * Returns the last key stored in this has map for the corresponding
+     * most recent call to {@link #containsKey}.
+     *
+     * <p>Use the following snippet of code to check for key existence
+     * first and then retrieve the key value if it exists.</p>
+     * <pre>
+     * if (map.containsKey(key))
+     *   value = map.lkey(); 
+     * </pre>
+     *
+     * <p>This is equivalent to calling:</p>
+     * <pre>
+     * if (map.containsKey(key))
+     *   key = map.keys[map.lslot()];
+     * </pre>
+     */
+    public KType lkey()
+    {
+        return keys[lslot()];
+    }
+    /* #end */
+
+    /**
+     * Returns the last value saved in a call to {@link #containsKey}.
+     *
+     * @see #containsKey
+     */
+    public VType lget()
+    {
+        assert lastSlot >= 0 : "Call containsKey() first.";
+        assert allocated[lastSlot] : "Last call to exists did not have any associated value.";
+
+        return values[lastSlot];
+    }
+
+    /**
+     * Sets the value corresponding to the key saved in the last
+     * call to {@link #containsKey}, if and only if the key exists
+     * in the map already.
+     *
+     * @see #containsKey
+     * @return Returns the previous value stored under the given key.
+     */
+    public VType lset(VType key)
+    {
+        assert lastSlot >= 0 : "Call containsKey() first.";
+        assert allocated[lastSlot] : "Last call to exists did not have any associated value.";
+
+        final VType previous = values[lastSlot];
+        values[lastSlot] = key;
+        return previous;
+    }
+
+    /**
+     * @return Returns the slot of the last key looked up in a call to {@link #containsKey} if
+     * it returned <code>true</code>.
+     *
+     * @see #containsKey
+     */
+    public int lslot()
+    {
+        assert lastSlot >= 0 : "Call containsKey() first.";
+        return lastSlot;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Saves the associated value for fast access using {@link #lget}
+     * or {@link #lset}.</p>
+     * <pre>
+     * if (map.containsKey(key))
+     *   value = map.lget();
+     * </pre>
+     * or, to modify the value at the given key without looking up
+     * its slot twice:
+     * <pre>
+     * if (map.containsKey(key))
+     *   map.lset(map.lget() + 1);
+     * </pre>
+     * #if ($TemplateOptions.KTypeGeneric) or, to retrieve the key-equivalent object from the map:
+     * <pre>
+     * if (map.containsKey(key))
+     *   map.lkey();
+     * </pre>#end
+     *
+     * <p><strong>Important:</strong> {@link #containsKey} and consecutive {@link #lget}, {@link #lset}
+     * or {@link #lkey} must not be used by concurrent threads because {@link #lastSlot} is 
+     * used to store state.</p>
+     */
+    @Override
+    public boolean containsKey(KType key)
+    {
+        lastSlot = lookupSlot(key);
+        return lastSlot != -1;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Does not release internal buffers.</p>
+     */
+    @Override
+    public void clear()
+    {
+        assigned = 0;
+
+        // States are always cleared.
+        Arrays.fill(allocated, false);
+
+        /* #if ($TemplateOptions.KTypeGeneric) */
+        Arrays.fill(keys, null); // Help the GC.
+        /* #end */
+
+        /* #if ($TemplateOptions.VTypeGeneric) */
+        Arrays.fill(values, null); // Help the GC.
+        /* #end */
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int size()
+    {
+        return assigned;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note that an empty container may still contain many deleted keys (that occupy buffer
+     * space). Adding even a single element to such a container may cause rehashing.</p>
+     */
+    public boolean isEmpty()
+    {
+        return size() == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode()
+    {
+        int h = 0;
+        for (KTypeVTypeCursor<KType, VType> c : this)
+        {
+            h += rehash(c.key) + rehash(c.value);
+        }
+        return h;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj != null)
+        {
+            if (obj == this) return true;
+
+            if (obj instanceof KTypeVTypeMap)
+            {
+                /* #if ($TemplateOptions.AnyGeneric) */
+                @SuppressWarnings("unchecked")
+                /* #end */
+                        KTypeVTypeMap<KType, VType> other = (KTypeVTypeMap<KType, VType>) obj;
+                if (other.size() == this.size())
+                {
+                    for (KTypeVTypeCursor<KType, VType> c : this)
+                    {
+                        if (other.containsKey(c.key))
+                        {
+                            VType v = other.get(c.key);
+                            if (Intrinsics.equalsVType(c.value, v))
+                            {
+                                continue;
+                            }
+                        }
+                        return false;
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * An iterator implementation for {@link #iterator}.
+     */
+    private final class EntryIterator extends AbstractIterator<KTypeVTypeCursor<KType, VType>>
+    {
+        private final KTypeVTypeCursor<KType, VType> cursor;
+
+        public EntryIterator()
+        {
+            cursor = new KTypeVTypeCursor<KType, VType>();
+            cursor.index = -1;
+        }
+
+        @Override
+        protected KTypeVTypeCursor<KType, VType> fetch()
+        {
+            int i = cursor.index + 1;
+            final int max = keys.length;
+            while (i < max && !allocated[i])
+            {
+                i++;
+            }
+
+            if (i == max)
+                return done();
+
+            cursor.index = i;
+            cursor.key = keys[i];
+            cursor.value = values[i];
+
+            return cursor;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterator<KTypeVTypeCursor<KType, VType>> iterator()
+    {
+        return new EntryIterator();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T extends KTypeVTypeProcedure<? super KType, ? super VType>> T forEach(T procedure)
+    {
+        final KType [] keys = this.keys;
+        final VType [] values = this.values;
+        final boolean [] states = this.allocated;
+
+        for (int i = 0; i < states.length; i++)
+        {
+            if (states[i])
+                procedure.apply(keys[i], values[i]);
+        }
+
+        return procedure;
+    }
+
+    /**
+     * Returns a specialized view of the keys of this associated container. 
+     * The view additionally implements {@link ObjectLookupContainer}.
+     */
+    public KeysContainer keys()
+    {
+        return new KeysContainer();
+    }
+
+    /**
+     * A view of the keys inside this hash map.
+     */
+    public final class KeysContainer
+            extends AbstractKTypeCollection<KType> implements KTypeLookupContainer<KType>
+    {
+        private final KTypeVTypeRobinHoodHashMap<KType, VType> owner =
+                KTypeVTypeRobinHoodHashMap.this;
+
+        @Override
+        public boolean contains(KType e)
+        {
+            return containsKey(e);
+        }
+
+        @Override
+        public <T extends KTypeProcedure<? super KType>> T forEach(T procedure)
+        {
+            final KType [] localKeys = owner.keys;
+            final boolean [] localStates = owner.allocated;
+
+            for (int i = 0; i < localStates.length; i++)
+            {
+                if (localStates[i])
+                    procedure.apply(localKeys[i]);
+            }
+
+            return procedure;
+        }
+
+        @Override
+        public <T extends KTypePredicate<? super KType>> T forEach(T predicate)
+        {
+            final KType [] localKeys = owner.keys;
+            final boolean [] localStates = owner.allocated;
+
+            for (int i = 0; i < localStates.length; i++)
+            {
+                if (localStates[i])
+                {
+                    if (!predicate.apply(localKeys[i]))
+                        break;
+                }
+            }
+
+            return predicate;
+        }
+
+        @Override
+        public boolean isEmpty()
+        {
+            return owner.isEmpty();
+        }
+
+        @Override
+        public Iterator<KTypeCursor<KType>> iterator()
+        {
+            return new KeysIterator();
+        }
+
+        @Override
+        public int size()
+        {
+            return owner.size();
+        }
+
+        @Override
+        public void clear()
+        {
+            owner.clear();
+        }
+
+        @Override
+        public int removeAll(KTypePredicate<? super KType> predicate)
+        {
+            return owner.removeAll(predicate);
+        }
+
+        @Override
+        public int removeAllOccurrences(final KType e)
+        {
+            final boolean hasKey = owner.containsKey(e);
+            int result = 0;
+            if (hasKey)
+            {
+                owner.remove(e);
+                result = 1;
+            }
+            return result;
+        }
+    };
+
+    /**
+     * An iterator over the set of assigned keys.
+     */
+    private final class KeysIterator extends AbstractIterator<KTypeCursor<KType>>
+    {
+        private final KTypeCursor<KType> cursor;
+
+        public KeysIterator()
+        {
+            cursor = new KTypeCursor<KType>();
+            cursor.index = -1;
+        }
+
+        @Override
+        protected KTypeCursor<KType> fetch()
+        {
+            int i = cursor.index + 1;
+            final int max = keys.length;
+            while (i < max && !allocated[i])
+            {
+                i++;
+            }
+
+            if (i == max)
+                return done();
+
+            cursor.index = i;
+            cursor.value = keys[i];
+
+            return cursor;
+        }
+    }
+
+    /**
+     * @return Returns a container with all values stored in this map.
+     */
+    @Override
+    public KTypeContainer<VType> values()
+    {
+        return new ValuesContainer();
+    }
+
+    /**
+     * A view over the set of values of this map.                                                                                                         
+     */
+    private final class ValuesContainer extends AbstractKTypeCollection<VType>
+    {
+        @Override
+        public int size()
+        {
+            return KTypeVTypeRobinHoodHashMap.this.size();
+        }
+
+        @Override
+        public boolean isEmpty()
+        {
+            return KTypeVTypeRobinHoodHashMap.this.isEmpty();
+        }
+
+        @Override
+        public boolean contains(VType value)
+        {
+            // This is a linear scan over the values, but it's in the contract, so be it.                                                     
+            final boolean [] allocated = KTypeVTypeRobinHoodHashMap.this.allocated;
+            final VType [] values = KTypeVTypeRobinHoodHashMap.this.values;
+
+            for (int slot = 0; slot < allocated.length; slot++)
+            {
+                if (allocated[slot] && Intrinsics.equalsVType(value, values[slot]))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public <T extends KTypeProcedure<? super VType>> T forEach(T procedure)
+        {
+            final boolean [] allocated = KTypeVTypeRobinHoodHashMap.this.allocated;
+            final VType [] values = KTypeVTypeRobinHoodHashMap.this.values;
+
+            for (int i = 0; i < allocated.length; i++)
+            {
+                if (allocated[i])
+                    procedure.apply(values[i]);
+            }
+
+            return procedure;
+        }
+
+        @Override
+        public <T extends KTypePredicate<? super VType>> T forEach(T predicate)
+        {
+            final boolean [] allocated = KTypeVTypeRobinHoodHashMap.this.allocated;
+            final VType [] values = KTypeVTypeRobinHoodHashMap.this.values;
+
+            for (int i = 0; i < allocated.length; i++)
+            {
+                if (allocated[i])
+                {
+                    if (!predicate.apply(values[i]))
+                        break;
+                }
+            }
+
+            return predicate;
+        }
+
+        @Override
+        public Iterator<KTypeCursor<VType>> iterator()
+        {
+            return new ValuesIterator();
+        }
+
+        @Override
+        public int removeAllOccurrences(VType e)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int removeAll(KTypePredicate<? super VType> predicate)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void clear()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * An iterator over the set of assigned values.                                                                                           
+     */
+    private final class ValuesIterator extends AbstractIterator<KTypeCursor<VType>>
+    {
+        private final KTypeCursor<VType> cursor;
+
+        public ValuesIterator()
+        {
+            cursor = new KTypeCursor<VType>();
+            cursor.index = -1;
+        }
+
+        @Override
+        protected KTypeCursor<VType> fetch()
+        {
+            int i = cursor.index + 1;
+            final int max = keys.length;
+            while (i < max && !allocated[i])
+            {
+                i++;
+            }
+
+            if (i == max)
+                return done();
+
+            cursor.index = i;
+            cursor.value = values[i];
+
+            return cursor;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KTypeVTypeRobinHoodHashMap<KType, VType> clone()
+    {
+        try
+        {
+            /* #if ($TemplateOptions.AnyGeneric) */
+            @SuppressWarnings("unchecked")
+            /* #end */
+                    KTypeVTypeRobinHoodHashMap<KType, VType> cloned =
+                    (KTypeVTypeRobinHoodHashMap<KType, VType>) super.clone();
+
+            cloned.keys = keys.clone();
+            cloned.values = values.clone();
+            cloned.allocated = allocated.clone();
+
+            return cloned;
+        }
+        catch (CloneNotSupportedException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Convert the contents of this map to a human-friendly string. 
+     */
+    @Override
+    public String toString()
+    {
+        final StringBuilder buffer = new StringBuilder();
+        buffer.append("[");
+
+        boolean first = true;
+        for (KTypeVTypeCursor<KType, VType> cursor : this)
+        {
+            if (!first) buffer.append(", ");
+            buffer.append(cursor.key);
+            buffer.append("=>");
+            buffer.append(cursor.value);
+            first = false;
+        }
+        buffer.append("]");
+        return buffer.toString();
+    }
+
+    /**
+     * Creates a hash map from two index-aligned arrays of key-value pairs. 
+     */
+    public static <KType, VType> KTypeVTypeRobinHoodHashMap<KType, VType> from(KType [] keys, VType [] values)
+    {
+        if (keys.length != values.length)
+            throw new IllegalArgumentException("Arrays of keys and values must have an identical length.");
+
+        KTypeVTypeRobinHoodHashMap<KType, VType> map = new KTypeVTypeRobinHoodHashMap<KType, VType>();
+        for (int i = 0; i < keys.length; i++)
+        {
+            map.put(keys[i], values[i]);
+        }
+        return map;
+    }
+
+    /**
+     * Create a hash map from another associative container.
+     */
+    public static <KType, VType> KTypeVTypeRobinHoodHashMap<KType, VType> from(KTypeVTypeAssociativeContainer<KType, VType> container)
+    {
+        return new KTypeVTypeRobinHoodHashMap<KType, VType>(container);
+    }
+
+    /**
+     * Create a new hash map without providing the full generic signature (constructor
+     * shortcut). 
+     */
+    public static <KType, VType> KTypeVTypeRobinHoodHashMap<KType, VType> newInstance()
+    {
+        return new KTypeVTypeRobinHoodHashMap<KType, VType>();
+    }
+
+    /**
+     * Returns a new object with no key perturbations (see
+     * {@link #computePerturbationValue(int)}). Only use when sure the container will not
+     * be used for direct copying of keys to another hash container.
+     */
+    public static <KType, VType> KTypeVTypeRobinHoodHashMap<KType, VType> newInstanceWithoutPerturbations()
+    {
+        return new KTypeVTypeRobinHoodHashMap<KType, VType>() {
+            @Override
+            protected int computePerturbationValue(int capacity) { return 0; }
+        };
+    }
+
+    /**
+     * Create a new hash map without providing the full generic signature (constructor
+     * shortcut). 
+     */
+    public static <KType, VType> KTypeVTypeRobinHoodHashMap<KType, VType> newInstance(int initialCapacity, float loadFactor)
+    {
+        return new KTypeVTypeRobinHoodHashMap<KType, VType>(initialCapacity, loadFactor);
+    }
+
+    /**
+     * Create a new hash map without providing the full generic signature (constructor
+     * shortcut). The returned instance will have enough initial capacity to hold
+     * <code>expectedSize</code> elements without having to resize.
+     */
+    public static <KType, VType> KTypeVTypeRobinHoodHashMap<KType, VType> newInstanceWithExpectedSize(int expectedSize)
+    {
+        return newInstanceWithExpectedSize(expectedSize, DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Create a new hash map without providing the full generic signature (constructor
+     * shortcut). The returned instance will have enough initial capacity to hold
+     * <code>expectedSize</code> elements without having to resize.
+     */
+    public static <KType, VType> KTypeVTypeRobinHoodHashMap<KType, VType> newInstanceWithExpectedSize(int expectedSize, float loadFactor)
+    {
+        return newInstance((int) (expectedSize / loadFactor) + 1, loadFactor);
+    }
+}

--- a/hppc-core/src/test/templates/com/carrotsearch/hppc/KTypeVTypeRobinHoodHashMapTest.java
+++ b/hppc-core/src/test/templates/com/carrotsearch/hppc/KTypeVTypeRobinHoodHashMapTest.java
@@ -1,0 +1,880 @@
+package com.carrotsearch.hppc;
+
+import static com.carrotsearch.hppc.TestUtils.*;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
+import java.util.*;
+
+import org.junit.*;
+
+import com.carrotsearch.hppc.cursors.*;
+import com.carrotsearch.hppc.predicates.*;
+import com.carrotsearch.hppc.procedures.*;
+
+/**
+ * Tests for {@link KTypeVTypeRobinHoodHashMap}.
+ */
+/* ! ${TemplateOptions.generatedAnnotation} ! */
+public class KTypeVTypeRobinHoodHashMapTest<KType, VType> extends AbstractKTypeTest<KType>
+{
+    protected VType value0 = vcast(0);
+    protected VType value1 = vcast(1);
+    protected VType value2 = vcast(2);
+    protected VType value3 = vcast(3);
+
+    /**
+     * Per-test fresh initialized instance.
+     */
+    public KTypeVTypeRobinHoodHashMap<KType, VType> map = KTypeVTypeRobinHoodHashMap.newInstance();
+
+    @After
+    public void checkEmptySlotsUninitialized()
+    {
+        if (map != null)
+        {
+            int occupied = 0;
+            for (int i = 0; i < map.keys.length; i++)
+            {
+                if (!map.allocated[i])
+                {
+                    /*! #if ($TemplateOptions.KTypeGeneric) !*/
+                    assertEquals2(Intrinsics.defaultKTypeValue(), map.keys[i]);
+                    /*! #end !*/
+                    /*! #if ($TemplateOptions.VTypeGeneric) !*/
+                    assertEquals2(Intrinsics.defaultVTypeValue(), map.values[i]);
+                    /*! #end !*/
+                }
+                else
+                {
+                    occupied++;
+                }
+            }
+            assertEquals(occupied, map.assigned);
+        }
+    }
+
+    /**
+     * Convert to target type from an integer used to test stuff. 
+     */
+    protected VType vcast(int value)
+    {
+        /*! #if ($TemplateOptions.VTypePrimitive)
+            return (VType) value;
+            #else !*/
+        @SuppressWarnings("unchecked")
+        VType v = (VType)(Object) value;
+        return v;
+        /*! #end !*/
+    }
+
+    /**
+     * Create a new array of a given type and copy the arguments to this array.
+     */
+    protected VType [] newvArray(VType... elements)
+    {
+        return elements;
+    }
+
+    private void assertSameMap(
+            final KTypeVTypeMap<KType, VType> c1,
+            final KTypeVTypeMap<KType, VType> c2)
+    {
+        assertEquals(c1.size(), c2.size());
+
+        c1.forEach(new KTypeVTypeProcedure<KType, VType>()
+        {
+            public void apply(KType key, VType value)
+            {
+                assertTrue(c2.containsKey(key));
+                assertEquals2(value, c2.get(key));
+            }
+        });
+    }
+
+    /* */
+    @Test
+    public void testCloningConstructor()
+    {
+        map.put(key1, value1);
+        map.put(key2, value2);
+        map.put(key3, value3);
+
+        assertSameMap(map, KTypeVTypeRobinHoodHashMap.from(map));
+        assertSameMap(map, new KTypeVTypeRobinHoodHashMap<KType, VType>(map));
+    }
+
+    /* */
+    /*! #if ($TemplateOptions.VTypeGeneric) !*/
+    @SuppressWarnings("unchecked")
+    /*! #end !*/
+    @Test
+    public void testFromArrays()
+    {
+        map.put(key1, value1);
+        map.put(key2, value2);
+        map.put(key3, value3);
+
+        KTypeVTypeRobinHoodHashMap<KType, VType> map2 = KTypeVTypeRobinHoodHashMap.from(
+                newArray(key1, key2, key3),
+                newvArray(value1, value2, value3));
+
+        assertSameMap(map, map2);
+    }
+
+    @Test
+    public void testGetOrDefault()
+    {
+        map.put(key2, value2);
+        assertTrue(map.containsKey(key2));
+
+        map.put(key1, value1);
+        assertEquals2(value1, map.getOrDefault(key1, value3));
+        assertEquals2(value3, map.getOrDefault(key3, value3));
+        map.remove(key1);
+        assertEquals2(value3, map.getOrDefault(key1, value3));
+
+        // Make sure lslot wasn't touched.
+        assertEquals2(value2, map.lget());
+    }
+
+    /* */
+    @Test
+    public void testPut()
+    {
+        map.put(key1, value1);
+
+        assertTrue(map.containsKey(key1));
+        assertEquals2(value1, map.lget());
+        assertEquals2(value1, map.get(key1));
+    }
+
+    /* */
+    @Test
+    public void testLPut()
+    {
+        map.put(key1, value2);
+        if (map.containsKey(key1))
+            map.lset(value3);
+
+        assertTrue(map.containsKey(key1));
+        assertEquals2(value3, map.lget());
+        assertEquals2(value3, map.get(key1));
+    }
+
+    /* */
+    @Test
+    public void testPutOverExistingKey()
+    {
+        map.put(key1, value1);
+        assertEquals2(value1, map.put(key1, value3));
+        assertEquals2(value3, map.get(key1));
+    }
+
+    /* */
+    @Test
+    public void testPutWithExpansions()
+    {
+        final int COUNT = 10000;
+        final Random rnd = new Random();
+        final HashSet<Object> values = new HashSet<Object>();
+
+        for (int i = 0; i < COUNT; i++)
+        {
+            final int v = rnd.nextInt();
+            final boolean hadKey = values.contains(cast(v));
+            values.add(cast(v));
+
+            assertEquals(hadKey, map.containsKey(cast(v)));
+            map.put(cast(v), vcast(v));
+            assertEquals(values.size(), map.size());
+        }
+        assertEquals(values.size(), map.size());
+    }
+
+    /* */
+    @Test
+    public void testPutAll()
+    {
+        map.put(key1, value1);
+        map.put(key2, value1);
+
+        KTypeVTypeRobinHoodHashMap<KType, VType> map2 =
+                new KTypeVTypeRobinHoodHashMap<KType, VType>();
+
+        map2.put(key2, value2);
+        map2.put(key3, value1);
+
+        // One new key (key3).
+        assertEquals(1, map.putAll(map2));
+
+        // Assert the value under key2 has been replaced.
+        assertEquals2(value2, map.get(key2));
+
+        // And key3 has been added.
+        assertEquals2(value1, map.get(key3));
+        assertEquals(3, map.size());
+    }
+
+    /* */
+    @Test
+    public void testPutIfAbsent()
+    {
+        assertTrue(map.putIfAbsent(key1, value1));
+        assertFalse(map.putIfAbsent(key1, value2));
+        assertEquals2(value1, map.get(key1));
+    }
+
+    /*! #if ($TemplateOptions.VTypePrimitive)
+    @Test
+    public void testPutOrAdd()
+    {
+        assertEquals2(value1, map.putOrAdd(key1, value1, value2));
+        assertEquals2(value1 + value2, map.putOrAdd(key1, value1, value2));
+    }
+    #end !*/
+
+    /*! #if ($TemplateOptions.VTypePrimitive)
+    @Test
+    public void testAddTo()
+    {
+        assertEquals2(value1, map.addTo(key1, value1));
+        assertEquals2(value1 + value2, map.addTo(key1, value2));
+    }
+    #end !*/
+
+    /* */
+    @Test
+    public void testRemove()
+    {
+        map.put(key1, value1);
+        assertEquals2(value1, map.remove(key1));
+        assertEquals2(Intrinsics.defaultVTypeValue(), map.remove(key1));
+        assertEquals(0, map.size());
+
+        // These are internals, but perhaps worth asserting too.
+        assertEquals(0, map.assigned);
+    }
+
+    /* */
+    @Test
+    public void testRemoveAllWithContainer()
+    {
+        map.put(key1, value1);
+        map.put(key2, value1);
+        map.put(key3, value1);
+
+        KTypeArrayList<KType> list2 = KTypeArrayList.newInstance();
+        list2.add(newArray(key2, key3, key4));
+
+        map.removeAll(list2);
+        assertEquals(1, map.size());
+        assertTrue(map.containsKey(key1));
+    }
+
+    /* */
+    @Test
+    public void testRemoveAllWithPredicate()
+    {
+        map.put(key1, value1);
+        map.put(key2, value1);
+        map.put(key3, value1);
+
+        map.removeAll(new KTypePredicate<KType>()
+        {
+            public boolean apply(KType value)
+            {
+                return value == key2 || value == key3;
+            }
+        });
+        assertEquals(1, map.size());
+        assertTrue(map.containsKey(key1));
+    }
+
+    /* */
+    @Test
+    public void testRemoveViaKeySetView()
+    {
+        map.put(key1, value1);
+        map.put(key2, value1);
+        map.put(key3, value1);
+
+        map.keys().removeAll(new KTypePredicate<KType>()
+        {
+            public boolean apply(KType value)
+            {
+                return value == key2 || value == key3;
+            }
+        });
+        assertEquals(1, map.size());
+        assertTrue(map.containsKey(key1));
+    }
+
+    /* */
+    @Test
+    public void testMapsIntersection()
+    {
+        KTypeVTypeRobinHoodHashMap<KType, VType> map2 =
+                KTypeVTypeRobinHoodHashMap.newInstance();
+
+        map.put(key1, value1);
+        map.put(key2, value1);
+        map.put(key3, value1);
+
+        map2.put(key2, value1);
+        map2.put(key4, value1);
+
+        assertEquals(2, map.keys().retainAll(map2.keys()));
+
+        assertEquals(1, map.size());
+        assertTrue(map.containsKey(key2));
+    }
+
+    /* */
+    @Test
+    public void testMapKeySet()
+    {
+        map.put(key1, value3);
+        map.put(key2, value2);
+        map.put(key3, value1);
+
+        assertSortedListEquals(map.keys().toArray(), key1, key2, key3);
+    }
+
+    /* */
+    @Test
+    public void testMapKeySetIterator()
+    {
+        map.put(key1, value3);
+        map.put(key2, value2);
+        map.put(key3, value1);
+
+        int counted = 0;
+        for (KTypeCursor<KType> c : map.keys())
+        {
+            assertEquals2(map.keys[c.index], c.value);
+            counted++;
+        }
+        assertEquals(counted, map.size());
+    }
+
+    /* */
+    @Test
+    public void testClear()
+    {
+        map.put(key1, value1);
+        map.put(key2, value1);
+        map.clear();
+        assertEquals(0, map.size());
+
+        // These are internals, but perhaps worth asserting too.
+        assertEquals(0, map.assigned);
+
+        // Check if the map behaves properly upon subsequent use.
+        testPutWithExpansions();
+    }
+
+    /* */
+    @Test
+    public void testRoundCapacity()
+    {
+        assertEquals(0x40000000, HashContainerUtils.roundCapacity(Integer.MAX_VALUE));
+        assertEquals(0x40000000, HashContainerUtils.roundCapacity(Integer.MAX_VALUE / 2 + 1));
+        assertEquals(0x40000000, HashContainerUtils.roundCapacity(Integer.MAX_VALUE / 2));
+        assertEquals(KTypeVTypeRobinHoodHashMap.MIN_CAPACITY, HashContainerUtils.roundCapacity(0));
+        assertEquals(Math.max(4, KTypeVTypeRobinHoodHashMap.MIN_CAPACITY), HashContainerUtils.roundCapacity(3));
+    }
+
+    /* */
+    @Test
+    public void testIterable()
+    {
+        map.put(key1, value1);
+        map.put(key2, value2);
+        map.put(key3, value3);
+        map.remove(key2);
+
+        int count = 0;
+        for (KTypeVTypeCursor<KType, VType> cursor : map)
+        {
+            count++;
+            assertTrue(map.containsKey(cursor.key));
+            assertEquals2(cursor.value, map.get(cursor.key));
+
+            assertEquals2(cursor.value, map.values[cursor.index]);
+            assertEquals2(cursor.key, map.keys[cursor.index]);
+            assertEquals2(true, map.allocated[cursor.index]);
+        }
+        assertEquals(count, map.size());
+
+        map.clear();
+        assertFalse(map.iterator().hasNext());
+    }
+
+    /* */
+    @Test
+    public void testFullLoadFactor()
+    {
+        map = new KTypeVTypeRobinHoodHashMap<KType, VType>(1, 1f);
+
+        // Fit in the byte key range.
+        int capacity = 0x80;
+        int max = capacity - 1;
+        for (int i = 0; i < max; i++)
+        {
+            map.put(cast(i), value1);
+        }
+
+        // Still not expanded.
+        assertEquals(max, map.size());
+        assertEquals(capacity, map.keys.length);
+        // Won't expand (existing key).
+        map.put(cast(0), value2);
+        assertEquals(capacity, map.keys.length);
+        // Expanded.
+        map.put(cast(0xff), value2);
+        assertEquals(2 * capacity, map.keys.length);
+    }
+
+
+    /* */
+    @Test
+    public void testBug_HPPC73_FullCapacityGet()
+    {
+        map = new KTypeVTypeRobinHoodHashMap<KType, VType>(1, 1f);
+        int capacity = 0x80;
+        int max = capacity - 1;
+        for (int i = 0; i < max; i++)
+        {
+            map.put(cast(i), value1);
+        }
+        assertEquals(max, map.size());
+        assertEquals(capacity, map.keys.length);
+
+        // Non-existent key.
+        map.remove(cast(max + 1));
+        assertFalse(map.containsKey(cast(max + 1)));
+        assertEquals2(Intrinsics.defaultVTypeValue(), map.get(cast(max + 1)));
+
+        // Should not expand because we're replacing an existing element.
+        map.put(cast(0), value2);
+        assertEquals(max, map.size());
+        assertEquals(capacity, map.keys.length);
+
+        map.putIfAbsent(cast(0), value3);
+        assertEquals(max, map.size());
+        assertEquals(capacity, map.keys.length);
+
+        // Remove from a full map.
+        map.remove(cast(0));
+        assertEquals(max - 1, map.size());
+        assertEquals(capacity, map.keys.length);
+    }
+
+    /* */
+    @Test
+    public void testHalfLoadFactor()
+    {
+        map = new KTypeVTypeRobinHoodHashMap<KType, VType>(1, 0.5f);
+
+        int capacity = 0x80;
+        int max = capacity - 1;
+        for (int i = 0; i < max; i++)
+        {
+            map.put(cast(i), value1);
+        }
+
+        assertEquals(max, map.size());
+        // Still not expanded.
+        assertEquals(2 * capacity, map.keys.length);
+        // Won't expand (existing key);
+        map.put(cast(0), value2);
+        assertEquals(2 * capacity, map.keys.length);
+        // Expanded.
+        map.put(cast(0xff), value1);
+        assertEquals(4 * capacity, map.keys.length);
+    }
+
+    /*! #if ($TemplateOptions.VTypeGeneric) !*/
+    @SuppressWarnings("unchecked")
+    /*! #end !*/
+    @Test
+    public void testHashCodeEquals()
+    {
+        KTypeVTypeRobinHoodHashMap<KType, VType> l0 =
+                new KTypeVTypeRobinHoodHashMap<KType, VType>();
+        assertEquals(0, l0.hashCode());
+        assertEquals(l0, new KTypeVTypeRobinHoodHashMap<KType, VType>());
+
+        KTypeVTypeRobinHoodHashMap<KType, VType> l1 = KTypeVTypeRobinHoodHashMap.from(
+                newArray(key1, key2, key3),
+                newvArray(value1, value2, value3));
+
+        KTypeVTypeRobinHoodHashMap<KType, VType> l2 = KTypeVTypeRobinHoodHashMap.from(
+                newArray(key2, key1, key3),
+                newvArray(value2, value1, value3));
+
+        KTypeVTypeRobinHoodHashMap<KType, VType> l3 = KTypeVTypeRobinHoodHashMap.from(
+                newArray(key1, key2),
+                newvArray(value2, value1));
+
+        assertEquals(l1.hashCode(), l2.hashCode());
+        assertEquals(l1, l2);
+
+        assertFalse(l1.equals(l3));
+        assertFalse(l2.equals(l3));
+    }
+
+    /* */
+    @Test
+    /*! #if ($TemplateOptions.VTypeGeneric) !*/
+    @SuppressWarnings("unchecked")
+    /*! #end !*/
+    public void testHashCodeEqualsDifferentPerturbance()
+    {
+        KTypeVTypeRobinHoodHashMap<KType, VType> l0 =
+                new KTypeVTypeRobinHoodHashMap<KType, VType>() {
+                    @Override
+                    protected int computePerturbationValue(int capacity)
+                    {
+                        return 0xDEADBEEF;
+                    }
+                };
+
+        KTypeVTypeRobinHoodHashMap<KType, VType> l1 =
+                new KTypeVTypeRobinHoodHashMap<KType, VType>() {
+                    @Override
+                    protected int computePerturbationValue(int capacity)
+                    {
+                        return 0xCAFEBABE;
+                    }
+                };
+
+        assertEquals(0, l0.hashCode());
+        assertEquals(l0.hashCode(), l1.hashCode());
+        assertEquals(l0, l1);
+
+        KTypeVTypeRobinHoodHashMap<KType, VType> l2 = KTypeVTypeRobinHoodHashMap.from(
+                newArray(key1, key2, key3),
+                newvArray(value1, value2, value3));
+
+        l0.putAll(l2);
+        l1.putAll(l2);
+
+        assertEquals(l0.hashCode(), l1.hashCode());
+        assertEquals(l0, l1);
+    }
+
+    /*! #if ($TemplateOptions.VTypeGeneric) !*/
+    @SuppressWarnings("unchecked")
+    /*! #end !*/
+    @Test
+    public void testBug_HPPC37()
+    {
+        KTypeVTypeRobinHoodHashMap<KType, VType> l1 = KTypeVTypeRobinHoodHashMap.from(
+                newArray(key1),
+                newvArray(value1));
+
+        KTypeVTypeRobinHoodHashMap<KType, VType> l2 = KTypeVTypeRobinHoodHashMap.from(
+                newArray(key2),
+                newvArray(value1));
+
+        assertFalse(l1.equals(l2));
+        assertFalse(l2.equals(l1));
+    }
+
+    /*! #if ($TemplateOptions.KTypeGeneric) !*/
+    @Test
+    public void testNullKey()
+    {
+        map.put(null, vcast(10));
+        assertEquals2(vcast(10), map.get(null));
+        assertTrue(map.containsKey(null));
+        assertEquals2(vcast(10), map.lget());
+        assertEquals2(null, map.lkey());
+        map.remove(null);
+        assertEquals(0, map.size());
+    }
+    /*! #end !*/
+
+    /*! #if ($TemplateOptions.KTypeGeneric) !*/
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLkey()
+    {
+        map.put(key1, vcast(10));
+        assertTrue(map.containsKey(key1));
+        assertSame(key1, map.lkey());
+        KType key1_ = (KType) new Integer(1);
+        assertNotSame(key1, key1_);
+        assertEquals(key1, key1_);
+        assertTrue(map.containsKey(key1_));
+        assertSame(key1, map.lkey());
+    }
+    /*! #end !*/
+
+    /*! #if ($TemplateOptions.VTypeGeneric) !*/
+    @Test
+    public void testNullValue()
+    {
+        map.put(key1, null);
+        assertEquals(null, map.get(key1));
+        assertTrue(map.containsKey(key1));
+        map.remove(key1);
+        assertFalse(map.containsKey(key1));
+        assertEquals(0, map.size());
+    }
+    /*! #end !*/
+
+    /*! #if ($TemplateOptions.AllGeneric) !*/
+    /**
+     * Run some random insertions/ deletions and compare the results
+     * against <code>java.util.HashMap</code>.
+     */
+    @Test
+    public void testAgainstHashMap()
+    {
+        final Random rnd = new Random();
+        final java.util.HashMap<KType, VType> other =
+                new java.util.HashMap<KType, VType>();
+
+        for (int size = 1000; size < 20000; size += 4000)
+        {
+            other.clear();
+            map.clear();
+
+            for (int round = 0; round < size * 20; round++)
+            {
+                KType key = cast(rnd.nextInt(size));
+                VType value = vcast(rnd.nextInt());
+
+                if (rnd.nextBoolean())
+                {
+                    map.put(key, value);
+                    other.put(key, value);
+
+
+                    assertEquals(value, map.get(key));
+                    assertTrue(map.containsKey(key));
+                    assertEquals(value, map.lget());
+                }
+                else
+                {
+                    assertEquals(other.remove(key), map.remove(key));
+                }
+
+                assertEquals(other.size(), map.size());
+            }
+        }
+    }
+    /*! #end !*/
+
+    /*
+     * 
+     */
+    @Test
+    public void testClone()
+    {
+        this.map.put(key1, value1);
+        this.map.put(key2, value2);
+        this.map.put(key3, value3);
+
+        KTypeVTypeRobinHoodHashMap<KType, VType> cloned = map.clone();
+        cloned.remove(key1);
+
+        assertSortedListEquals(map.keys().toArray(), key1, key2, key3);
+        assertSortedListEquals(cloned.keys().toArray(), key2, key3);
+    }
+
+    /*
+     * 
+     */
+    @Test
+    public void testToString()
+    {
+        Assume.assumeTrue(
+                (int[].class.isInstance(map.keys)     ||
+                        short[].class.isInstance(map.keys)   ||
+                        byte[].class.isInstance(map.keys)    ||
+                        long[].class.isInstance(map.keys)    ||
+                        Object[].class.isInstance(map.keys)) &&
+                        (int[].class.isInstance(map.values)   ||
+                                byte[].class.isInstance(map.values)  ||
+                                short[].class.isInstance(map.values) ||
+                                long[].class.isInstance(map.values)  ||
+                                Object[].class.isInstance(map.values)));
+
+        this.map.put(key1, value1);
+        this.map.put(key2, value2);
+
+        String asString = map.toString();
+        asString = asString.replaceAll("[^0-9]", "");
+        char [] asCharArray = asString.toCharArray();
+        Arrays.sort(asCharArray);
+        assertEquals("1122", new String(asCharArray));
+    }
+
+    @Test
+    public void testAddRemoveSameHashCollision()
+    {
+        // This test is only applicable to selected key types.
+        Assume.assumeTrue(
+                int[].class.isInstance(map.keys) ||
+                        long[].class.isInstance(map.keys) ||
+                        Object[].class.isInstance(map.keys));
+
+        IntArrayList hashChain = TestUtils.generateMurmurHash3CollisionChain(0x1fff, 0x7e, 0x1fff /3);
+
+        /*
+         * Add all of the conflicting keys to a map. 
+         */
+        for (IntCursor c : hashChain)
+            map.put(cast(c.value), this.value1);
+
+        assertEquals(hashChain.size(), map.size());
+        
+        /*
+         * Add some more keys (random).
+         */
+        Random rnd = new Random(0xbabebeef);
+        IntSet chainKeys = IntOpenHashSet.from(hashChain);
+        IntSet differentKeys = new IntOpenHashSet();
+        while (differentKeys.size() < 500)
+        {
+            int k = rnd.nextInt();
+            if (!chainKeys.contains(k) && !differentKeys.contains(k))
+                differentKeys.add(k);
+        }
+
+        for (IntCursor c : differentKeys)
+            map.put(cast(c.value), value2);
+
+        assertEquals(hashChain.size() + differentKeys.size(), map.size());
+
+        /* 
+         * Verify the map contains all of the conflicting keys.
+         */
+        for (IntCursor c : hashChain)
+            assertEquals2(value1, map.get(cast(c.value)));
+
+        /*
+         * Verify the map contains all the other keys.
+         */
+        for (IntCursor c : differentKeys)
+            assertEquals2(value2, map.get(cast(c.value)));
+
+        /*
+         * Iteratively remove the keys, from first to last.
+         */
+        for (IntCursor c : hashChain)
+            assertEquals2(value1, map.remove(cast(c.value)));
+
+        assertEquals(differentKeys.size(), map.size());
+        
+        /*
+         * Verify the map contains all the other keys.
+         */
+        for (IntCursor c : differentKeys)
+            assertEquals2(value2, map.get(cast(c.value)));
+    }
+
+    /* */
+    @Test
+    public void testMapValues()
+    {
+        map.put(key1, value3);
+        map.put(key2, value2);
+        map.put(key3, value1);
+        assertSortedListEquals(map.values().toArray(), value1, value2, value3);
+
+        map.clear();
+        map.put(key1, value1);
+        map.put(key2, value2);
+        map.put(key3, value2);
+        assertSortedListEquals(map.values().toArray(), value1, value2, value2);
+    }
+
+    /* */
+    @Test
+    public void testMapValuesIterator()
+    {
+        map.put(key1, value3);
+        map.put(key2, value2);
+        map.put(key3, value1);
+
+        int counted = 0;
+        for (KTypeCursor<VType> c : map.values())
+        {
+            assertEquals2(map.values[c.index], c.value);
+            counted++;
+        }
+        assertEquals(counted, map.size());
+    }
+
+    /* */
+    @Test
+    public void testMapValuesContainer()
+    {
+        map.put(key1, value1);
+        map.put(key2, value2);
+        map.put(key3, value2);
+
+        // contains()
+        for (KTypeVTypeCursor<KType, VType> c : map)
+            assertTrue(map.values().contains(c.value));
+        assertFalse(map.values().contains(value3));
+
+        assertEquals(map.isEmpty(), map.values().isEmpty());
+        assertEquals(map.size(), map.values().size());
+
+        final KTypeArrayList<VType> values = new KTypeArrayList<VType>();
+        map.values().forEach(new KTypeProcedure<VType>()
+        {
+            public void apply(VType value)
+            {
+                values.add(value);
+            }
+        });
+        assertSortedListEquals(map.values().toArray(), value1, value2, value2);
+
+        values.clear();
+        map.values().forEach(new KTypePredicate<VType>()
+        {
+            public boolean apply(VType value)
+            {
+                values.add(value);
+                return true;
+            }
+        });
+        assertSortedListEquals(map.values().toArray(), value1, value2, value2);
+    }
+
+    /**
+     * Tests that instances created with the <code>newInstanceWithExpectedSize</code>
+     * static factory methods do not have to resize to hold the expected number of elements.
+     */
+    @Test
+    public void testExpectedSizeInstanceCreation()
+    {
+        KTypeVTypeRobinHoodHashMap<KType, VType> fixture =
+                KTypeVTypeRobinHoodHashMap.newInstanceWithExpectedSize(KTypeVTypeRobinHoodHashMap.DEFAULT_CAPACITY);
+
+        assertEquals(KTypeVTypeRobinHoodHashMap.DEFAULT_CAPACITY, this.map.keys.length);
+        assertEquals(KTypeVTypeRobinHoodHashMap.DEFAULT_CAPACITY * 2, fixture.keys.length);
+
+        for (int i = 0; i < KTypeOpenHashSet.DEFAULT_CAPACITY; i++)
+        {
+            KType key = cast(i);
+            VType value = vcast(i);
+            this.map.put(key, value);
+            fixture.put(key, value);
+        }
+
+        assertEquals(KTypeVTypeRobinHoodHashMap.DEFAULT_CAPACITY * 2, this.map.keys.length);
+        assertEquals(KTypeVTypeRobinHoodHashMap.DEFAULT_CAPACITY * 2, fixture.keys.length);
+    }
+}


### PR DESCRIPTION
I implemented robin hood hashing using the existing open hash map and the algorithm discussed here: http://sebastiansylvan.com/2013/05/08/robin-hood-hashing-should-be-your-default-hash-table-implementation/.

Removes are still done via the shiftConflicingKeys method.  As discussed here http://sebastiansylvan.com/2013/08/05/more-on-robin-hood-hashing-2/ doing tombstones leads to long probe lengths when there are many removes and inserts of the same key.  This shows up pretty well in the test suite.  The existing shift scheme seems to be correct so I simply reused that.

Would like to do some performance testing and some comparison of probe length variance between this and the open hash map implementation.