### PR TITLE
HPPC-191: Refine Accountable implementation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,8 @@ HPPC-176: A new set of associative containers implementing Worm Hashing has been
 
 ** Improvements
 
+HPPC-191: Improve Accountable implementation (Haoyu Zhai)
+
 HPPC-183: Simplify IndirectSort comparator to use IntBinaryOperator.
 
 HPPC-177: Modernize the build system to gradle and make it work with IntelliJ.

--- a/hppc/src/main/java/com/carrotsearch/hppc/Accountable.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/Accountable.java
@@ -20,12 +20,12 @@ public interface Accountable {
    *
    * @return Ram allocated in bytes
    */
-  public long ramBytesAllocated();
+  long ramBytesAllocated();
 
   /**
    * Bytes that is actually been used
    *
    * @return Ram used in bytes
    */
-  public long ramBytesUsed();
+  long ramBytesUsed();
 }

--- a/hppc/src/main/java/com/carrotsearch/hppc/ArraySizingStrategy.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/ArraySizingStrategy.java
@@ -10,7 +10,7 @@
 package com.carrotsearch.hppc;
 
 /** Resizing (growth) strategy for array-backed buffers. */
-public interface ArraySizingStrategy {
+public interface ArraySizingStrategy extends Accountable {
   /**
    * @param currentBufferLength Current size of the array (buffer). This number should comply with
    *     the strategy's policies (it is a result of initial rounding or further growCalls). It can

--- a/hppc/src/main/java/com/carrotsearch/hppc/BoundedProportionalArraySizingStrategy.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/BoundedProportionalArraySizingStrategy.java
@@ -95,4 +95,16 @@ public final class BoundedProportionalArraySizingStrategy implements ArraySizing
 
     return (int) newSize;
   }
+
+  @Override
+  public long ramBytesAllocated() {
+    // int: minGrowCount, maxGrowCount
+    // float: growRatio
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES * 2 + Float.BYTES;
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return ramBytesAllocated();
+  }
 }

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayDeque.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayDeque.java
@@ -585,14 +585,14 @@ public class KTypeArrayDeque<KType>
   @Override
   public long ramBytesAllocated() {
     // int: head, tail
-    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES * 2 + RamUsageEstimator.shallowSizeOf(resizer)
-            + RamUsageEstimator.shallowSizeOf(buffer);
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES * 2 + resizer.ramBytesAllocated()
+            + RamUsageEstimator.shallowSizeOfArray(buffer);
   }
 
   @Override
   public long ramBytesUsed() {
     // int: head, tail
-    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES * 2 + RamUsageEstimator.shallowSizeOf(resizer)
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES * 2 + resizer.ramBytesUsed()
             + RamUsageEstimator.shallowUsedSizeOfArray(buffer, size());
   }
 

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayList.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayList.java
@@ -507,14 +507,14 @@ public class KTypeArrayList<KType>
   @Override
   public long ramBytesAllocated() {
     // int: elementsCount
-    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES + RamUsageEstimator.shallowSizeOf(resizer) +
-            RamUsageEstimator.shallowSizeOf(buffer);
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES + resizer.ramBytesAllocated() +
+            RamUsageEstimator.shallowSizeOfArray(buffer);
   }
 
   @Override
   public long ramBytesUsed() {
     // int: elementsCount
-    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES + RamUsageEstimator.shallowSizeOf(resizer) +
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES + resizer.ramBytesUsed() +
             RamUsageEstimator.shallowUsedSizeOfArray(buffer, elementsCount);
   }
 

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeHashSet.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeHashSet.java
@@ -467,7 +467,7 @@ public class KTypeHashSet<KType>
     // double: loadFactor
     // boolean: hasEmptyKey
     return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + 4 * Integer.BYTES + Double.BYTES + 1 +
-            RamUsageEstimator.shallowSizeOf(keys);
+            RamUsageEstimator.shallowSizeOfArray(keys);
   }
 
   @Override

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
@@ -26,7 +26,7 @@ public class KTypeVTypeHashMap<KType, VType>
              Cloneable,
              Accountable
 {
-  /** 
+  /**
    * The array holding keys.
    */
   public /*! #if ($TemplateOptions.KTypeGeneric) !*/ 
@@ -645,16 +645,16 @@ public class KTypeVTypeHashMap<KType, VType>
 
   @Override
   public long ramBytesAllocated() {
-    // int: keyMixer, assigned, mask, resizeAt
+    // int: iterationSeed, assigned, mask, resizeAt
     // double: loadFactor
     // boolean: hasEmptyKey
     return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + 4 * Integer.BYTES + Double.BYTES + 1 +
-            RamUsageEstimator.shallowSizeOf(keys) + RamUsageEstimator.shallowSizeOf(values);
+            RamUsageEstimator.shallowSizeOfArray(keys) + RamUsageEstimator.shallowSizeOfArray(values);
   }
 
   @Override
   public long ramBytesUsed() {
-    // int: keyMixer, assigned, mask, resizeAt
+    // int: iterationSeed, assigned, mask, resizeAt
     // double: loadFactor
     // boolean: hasEmptyKey
     return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + 4 * Integer.BYTES + Double.BYTES + 1 +

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeWormMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeWormMap.java
@@ -568,18 +568,18 @@ public class KTypeVTypeWormMap<KType, VType>
   /** {@inheritDoc} */
   @Override
   public long ramBytesAllocated() {
-    // int: size
-    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES
-            + RamUsageEstimator.shallowSizeOf(keys)
-            + RamUsageEstimator.shallowSizeOf(values)
-            + RamUsageEstimator.shallowSizeOf(next);
+    // int: size, iterationSeed
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES * 2
+            + RamUsageEstimator.shallowSizeOfArray(keys)
+            + RamUsageEstimator.shallowSizeOfArray(values)
+            + RamUsageEstimator.shallowSizeOfArray(next);
   }
 
   /** {@inheritDoc} */
   @Override
   public long ramBytesUsed() {
-    // int: size
-    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES
+    // int: size, iterationSeed
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES * 2
             + RamUsageEstimator.shallowUsedSizeOfArray(keys, size())
             + RamUsageEstimator.shallowUsedSizeOfArray(values, size())
             + RamUsageEstimator.shallowUsedSizeOfArray(next, size());

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeWormSet.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeWormSet.java
@@ -538,17 +538,17 @@ public class KTypeWormSet<KType>
   /** {@inheritDoc} */
   @Override
   public long ramBytesAllocated() {
-    // int: size
-    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES
-            + RamUsageEstimator.shallowSizeOf(keys)
-            + RamUsageEstimator.shallowSizeOf(next);
+    // int: size, iterationSeed
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES * 2
+            + RamUsageEstimator.shallowSizeOfArray(keys)
+            + RamUsageEstimator.shallowSizeOfArray(next);
   }
 
   /** {@inheritDoc} */
   @Override
   public long ramBytesUsed() {
-    // int: size
-    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES
+    // int: size, iterationSeed
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES * 2
             + RamUsageEstimator.shallowUsedSizeOfArray(keys, size())
             + RamUsageEstimator.shallowUsedSizeOfArray(next, size());
   }

--- a/hppc/src/test/java/com/carrotsearch/hppc/TightRandomResizingStrategy.java
+++ b/hppc/src/test/java/com/carrotsearch/hppc/TightRandomResizingStrategy.java
@@ -34,4 +34,15 @@ public final class TightRandomResizingStrategy implements ArraySizingStrategy {
 
     return Math.max(currentBufferLength, elementsCount + expectedAdditions) + r;
   }
+
+  @Override
+  public long ramBytesAllocated() {
+    // int: maxRandomIncrement, growCalls
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES * 2;
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return ramBytesAllocated();
+  }
 }


### PR DESCRIPTION
Remove slow reflective operations from Accountable implementation
Refine some of the existed counting

I made `ArraySizingStrategy` extend `Accountable` as well so that we don't need to use reflection to estimate the size. And since that seems more like a lightweight class I think the default estimation of object header should be enough for most cases