### PR TITLE
Reuse the same strategy instance

### DIFF
--- a/hppc/src/main/java/com/carrotsearch/hppc/BoundedProportionalArraySizingStrategy.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/BoundedProportionalArraySizingStrategy.java
@@ -22,6 +22,11 @@ import java.util.ArrayList;
  * </pre>
  */
 public final class BoundedProportionalArraySizingStrategy implements ArraySizingStrategy {
+
+  /** Instance of {@link BoundedProportionalArraySizingStrategy} with default values. */
+  public static final BoundedProportionalArraySizingStrategy DEFAULT_INSTANCE =
+      new BoundedProportionalArraySizingStrategy();
+
   /**
    * Maximum allocable array length (approximately the largest positive integer decreased by the
    * array's object header).

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayDeque.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayDeque.java
@@ -19,6 +19,13 @@ public class KTypeArrayDeque<KType>
              Preallocable, 
              Cloneable,
              Accountable {
+
+  /**
+   * Reuse the same strategy instance.
+   */
+  private static final BoundedProportionalArraySizingStrategy DEFAULT_SIZING_STRATEGY =
+      BoundedProportionalArraySizingStrategy.DEFAULT_INSTANCE;
+
   /**
    * Internal array for storing elements of the deque.
    */
@@ -62,7 +69,7 @@ public class KTypeArrayDeque<KType>
    *          expansion (inclusive).
    */
   public KTypeArrayDeque(int expectedElements) {
-    this(expectedElements, new BoundedProportionalArraySizingStrategy());
+    this(expectedElements, DEFAULT_SIZING_STRATEGY);
   }
 
   /**

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayList.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayList.java
@@ -37,6 +37,12 @@ public class KTypeArrayList<KType>
       /*! #end !*/; 
 
   /**
+   * Reuse the same strategy instance.
+   */
+  private static final BoundedProportionalArraySizingStrategy DEFAULT_SIZING_STRATEGY =
+      BoundedProportionalArraySizingStrategy.DEFAULT_INSTANCE;
+
+  /**
    * Internal array for storing the list. The array may be larger than the current size
    * ({@link #size()}).
    */
@@ -73,7 +79,7 @@ public class KTypeArrayList<KType>
    *          expansion (inclusive).
    */
   public KTypeArrayList(int expectedElements) {
-    this(expectedElements, new BoundedProportionalArraySizingStrategy());
+    this(expectedElements, DEFAULT_SIZING_STRATEGY);
   }
 
 


### PR DESCRIPTION
### Motivation
In my application code, I used a large number of `IntArrayList` that were created with the default constructor. When profiling the application, I noticed that a lot of allocations were spent on creating (identical) instances of `BoundedProportionalArraySizingStrategy`.
While specifying a fixed strategy instance is a relatively easy workaround, noticing this issue in the first place is a bit more difficult. I would like to prevent others from making the same mistake.

### Change
I changed the default constructor of `KTypeArrayList` and `KTypeArrayDeque` so that they reuse the same instance of `BoundedProportionalArraySizingStrategy` for all created objects. 

### Impact
With this change, only one instance of `BoundedProportionalArraySizingStrategy` is used for all instances of `KTypeArrayList` and `KTypeArrayDeque`. Since the strategy is immutable and otherwise identical instances would be used, I don't see any downside to this.
Also, it should be backwards-compatible.

### Verification
`gradle build` completes without issues for me.