### PR TITLE
Add some support for atomic and volatile methods on map types

### DIFF
--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeMap.java
@@ -174,6 +174,64 @@ public interface KTypeVTypeMap<KType, VType> extends KTypeVTypeAssociativeContai
   public VType indexReplace(int index, VType newValue);
 
   /**
+   * Returns the value associated with an existing key with volatile memory semantics.
+   *
+   * @see #indexOf
+   *
+   * @param index
+   *          The index of an existing key.
+   * @return Returns the value currently associated with the key.
+   * @throws AssertionError
+   *           If assertions are enabled and the index does not correspond to an
+   *           existing key.
+   */
+  public VType indexGetVolatile(int index);
+
+  /**
+   * Sets the value associated with an existing key with volatile memory semantics.
+   *
+   * @see #indexOf
+   *
+   * @param index
+   *          The index of an existing key.
+   * @throws AssertionError
+   *           If assertions are enabled and the index does not correspond to an
+   *           existing key.
+   */
+  public void indexSetVolatile(int index, VType newValue);
+
+  /**
+   * Atomically replaces the value associated with an existing key and returns any previous
+   * value stored for that key with volatile memory semantics.
+   *
+   * @see #indexOf
+   *
+   * @param index
+   *          The index of an existing key.
+   * @return Returns the previous value associated with the key.
+   * @throws AssertionError
+   *           If assertions are enabled and the index does not correspond to an
+   *           existing key.
+   */
+  public VType indexReplaceVolatile(int index, VType newValue);
+
+  /**
+   * Atomically replaces the value associated with an existing key and returns the previous
+   * value stored for that key but only if the previous value is equal to the expected
+   * value.
+   *
+   * @see #indexOf
+   *
+   * @param index
+   *          The index of an existing key.
+   * @return Returns the previous value associated with the key.
+   * @throws AssertionError
+   *           If assertions are enabled and the index does not correspond to an
+   *           existing key.
+   */
+  public VType indexCompareAndExchange(int index, VType expectedValue, VType newValue);
+
+  /**
    * Inserts a key-value pair for a key that is not present in the map. This
    * method may help in avoiding double recalculation of the key's hash.
    * 

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeHashMapTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeHashMapTest.java
@@ -198,6 +198,42 @@ public class KTypeVTypeHashMapTest<KType, VType> extends AbstractKTypeTest<KType
       Assertions.assertThat(map.size()).isEqualTo(3);
     }
 
+    @Test
+    public void testVolatileIndexMethods()
+    {
+        map.put(keyE, value1);
+        map.put(key1, value2);
+
+        map.indexSetVolatile(map.indexOf(keyE), value3);
+        map.indexSetVolatile(map.indexOf(key1), value4);
+        Assertions.assertThat(map.indexGetVolatile(map.indexOf(keyE))).isEqualTo(value3);
+        Assertions.assertThat(map.indexGetVolatile(map.indexOf(key1))).isEqualTo(value4);
+
+        Assertions.assertThat(map.indexReplaceVolatile(map.indexOf(keyE), value1)).isEqualTo(value3);
+        Assertions.assertThat(map.indexReplaceVolatile(map.indexOf(key1), value2)).isEqualTo(value4);
+        Assertions.assertThat(map.indexGet(map.indexOf(keyE))).isEqualTo(value1);
+        Assertions.assertThat(map.indexGet(map.indexOf(key1))).isEqualTo(value2);
+    }
+
+    @Test
+    public void testCompareAndExchange()
+    {
+        map.put(keyE, value1);
+        map.put(key1, value2);
+
+        // Comparison succeeds
+        Assertions.assertThat(map.indexCompareAndExchange(map.indexOf(keyE), value1, value3)).isEqualTo(value1);
+        Assertions.assertThat(map.indexCompareAndExchange(map.indexOf(key1), value2, value4)).isEqualTo(value2);
+        Assertions.assertThat(map.indexGet(map.indexOf(keyE))).isEqualTo(value3);
+        Assertions.assertThat(map.indexGet(map.indexOf(key1))).isEqualTo(value4);
+
+        // Comparison fails
+        Assertions.assertThat(map.indexCompareAndExchange(map.indexOf(keyE), value1, value1)).isEqualTo(value3);
+        Assertions.assertThat(map.indexCompareAndExchange(map.indexOf(key1), value2, value2)).isEqualTo(value4);
+        Assertions.assertThat(map.indexGet(map.indexOf(keyE))).isEqualTo(value3);
+        Assertions.assertThat(map.indexGet(map.indexOf(key1))).isEqualTo(value4);
+    }
+
     /* */
     @Test
     public void testCloningConstructor()

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeWormMapTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeWormMapTest.java
@@ -150,6 +150,42 @@ public class KTypeVTypeWormMapTest<KType, VType> extends AbstractKTypeTest<KType
       Assertions.assertThat(map.size()).isEqualTo(3);
     }
 
+    @Test
+    public void testVolatileIndexMethods()
+    {
+        map.put(keyE, value1);
+        map.put(key1, value2);
+
+        map.indexSetVolatile(map.indexOf(keyE), value3);
+        map.indexSetVolatile(map.indexOf(key1), value4);
+        Assertions.assertThat(map.indexGetVolatile(map.indexOf(keyE))).isEqualTo(value3);
+        Assertions.assertThat(map.indexGetVolatile(map.indexOf(key1))).isEqualTo(value4);
+
+        Assertions.assertThat(map.indexReplaceVolatile(map.indexOf(keyE), value1)).isEqualTo(value3);
+        Assertions.assertThat(map.indexReplaceVolatile(map.indexOf(key1), value2)).isEqualTo(value4);
+        Assertions.assertThat(map.indexGet(map.indexOf(keyE))).isEqualTo(value1);
+        Assertions.assertThat(map.indexGet(map.indexOf(key1))).isEqualTo(value2);
+    }
+
+    @Test
+    public void testCompareAndExchange()
+    {
+        map.put(keyE, value1);
+        map.put(key1, value2);
+
+        // Comparison succeeds
+        Assertions.assertThat(map.indexCompareAndExchange(map.indexOf(keyE), value1, value3)).isEqualTo(value1);
+        Assertions.assertThat(map.indexCompareAndExchange(map.indexOf(key1), value2, value4)).isEqualTo(value2);
+        Assertions.assertThat(map.indexGet(map.indexOf(keyE))).isEqualTo(value3);
+        Assertions.assertThat(map.indexGet(map.indexOf(key1))).isEqualTo(value4);
+
+        // Comparison fails
+        Assertions.assertThat(map.indexCompareAndExchange(map.indexOf(keyE), value1, value1)).isEqualTo(value3);
+        Assertions.assertThat(map.indexCompareAndExchange(map.indexOf(key1), value2, value2)).isEqualTo(value4);
+        Assertions.assertThat(map.indexGet(map.indexOf(keyE))).isEqualTo(value3);
+        Assertions.assertThat(map.indexGet(map.indexOf(key1))).isEqualTo(value4);
+    }
+
     /* */
     @Test
     public void testCloningConstructor()


### PR DESCRIPTION
I won't be disappointed if you don't accept this patch; it uses VarHandles, which were introduced in JDK 9, so if support for JDK 8 and earlier is important, you likely don't want this, at least in its present form. If these features are wanted but in a way that does not break JDK 8, one solution might be to use the template system to generate different code for JDK 8 versus 9 and only support these new methods for JDK 9.

My idea is that, because of the design of the index methods such as indexGet and indexReplace, I could extend the design to allow some limited concurrent operations on hash map types, permitting multiple threads to read and write values in parallel with well defined semantics. The main restriction is that while threads are using these new methods, no other thread may perform any action that would change the indexes of values, operations such as put or delete for example.

The new methods are indexGetVolatile, indexSetVolatile, indexReplaceVolatile and indexCompareAndExchange.

Here is an example of use. It follows the common CAS pattern of reading a variable with volatile semantics, preparing assuming its value will not change, then committing with an atomic CAS operation, abandoning and retrying if, due to concurrent operations, the assumption was incorrect.
```kotlin
// Multiple threads can run this concurrently on the same hash map.
// field "elements" is of type LongObjectHashMap<Element>
fun Version.upgradeToWritable(element: Element): Element {
    assertHasSharedLock()
    val id = element.id

    // Index will not be invalidated inside enclosing function because we have ensured that no
    // such invalidating operations will occur by some means, specifically by acquiring a shared
    // lock in this example.
    val idx = elements.indexOf(id)

    while (true) {
        // Check to see if another thread accomplished the upgrade before this thread. Note that if this
        // only called indexGet, the loop could hang indefinitely.
        val existingElement = elements.indexGetVolatile(idx)
        if (existingElement.version === this) {
            return existingElement
        }

        // Speculatively upgrade
        val speculativeElement = element.shallowCopy()
        speculativeElement.version = this

        // Only make the the speculative upgrade visible to other threads if the initial assumption was correct.
        // Otherwise retry.
        if (elements.indexCompareAndExchange(idx, existingElement, speculativeElement) === existingElement) {
            return speculativeElement
        }
    }
}
```

There are other operations I could have added and can if wanted. The reason I avoided adding indexGetAcquire and indexSetRelease is because they would be redundant. One can get the same effect by using VarHandle.acquireFence and VarHandle.releaseFence combined with the existing indexGet and indexReplace.

Technically, indexGetVolatile and indexSetVolatile are redundant too because one can get the same semantics by combining them with VarHandle.fullFence. However, some processors have special instructions for volatile access that might not be used if the volatile access is not explicit. At least, [Doug Lea said so](http://gee.cs.oswego.edu/dl/html/j9mm.html).

I included only the atomic operations that make sense for all types of value. For example, indexGetAndAdd would have been quite useful for integer valued hash maps but does not make sense for reference type valued ones.