### PR TITLE
Make WormMap KeysContainer public.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@
 
 ** New features and API changes
 
+   GH-20: KeysContainer of WormMap is not public (Haoyu Zhai, Bruno Roustant).
+
    GH-13: Add automatic module name to the generated JAR's manifest ("com.carrotsearch.hppc")
 
 HPPC-179: Update java template parser to support Java 8.

--- a/hppc-examples/src/test/java/com/carrotsearch/hppc/examples/HppcExample_004_IteratingOverMaps.java
+++ b/hppc-examples/src/test/java/com/carrotsearch/hppc/examples/HppcExample_004_IteratingOverMaps.java
@@ -65,11 +65,14 @@ public class HppcExample_004_IteratingOverMaps {
   /** A for-each type loop on keys. */
   @Test
   public void keys() {
-    wormMap.keys().forEach(new IntProcedure() {
-      @Override
-      public void apply(int key) {
-        printfln("key %d", key);
-      }
-    });
+    wormMap
+        .keys()
+        .forEach(
+            new IntProcedure() {
+              @Override
+              public void apply(int key) {
+                printfln("key %d", key);
+              }
+            });
   }
 }

--- a/hppc-examples/src/test/java/com/carrotsearch/hppc/examples/HppcExample_004_IteratingOverMaps.java
+++ b/hppc-examples/src/test/java/com/carrotsearch/hppc/examples/HppcExample_004_IteratingOverMaps.java
@@ -13,8 +13,10 @@ import static com.carrotsearch.hppc.examples.Helpers.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.carrotsearch.hppc.IntLongHashMap;
+import com.carrotsearch.hppc.IntLongWormMap;
 import com.carrotsearch.hppc.cursors.IntLongCursor;
 import com.carrotsearch.hppc.procedures.IntLongProcedure;
+import com.carrotsearch.hppc.procedures.IntProcedure;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,10 +24,13 @@ import org.junit.Test;
 public class HppcExample_004_IteratingOverMaps {
 
   public IntLongHashMap hashMap;
+  public IntLongWormMap wormMap;
 
   @Before
   public void setup() {
     hashMap = IntLongHashMap.from(new int[] {1, 1, 2, 3, 5, 0}, new long[] {1, 2, 3, 4, 5, 6});
+    // WormMap is a hash map efficient for less than 2M entries, and more get() than put().
+    wormMap = IntLongWormMap.from(new int[] {1, 1, 2, 3, 5, 0}, new long[] {1, 2, 3, 4, 5, 6});
   }
 
   /**
@@ -55,5 +60,16 @@ public class HppcExample_004_IteratingOverMaps {
             printfln("hashMap %d => %d", key, value);
           }
         });
+  }
+
+  /** A for-each type loop on keys. */
+  @Test
+  public void keys() {
+    wormMap.keys().forEach(new IntProcedure() {
+      @Override
+      public void apply(int key) {
+        printfln("key %d", key);
+      }
+    });
   }
 }

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeWormMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeWormMap.java
@@ -1023,7 +1023,7 @@ public class KTypeVTypeWormMap<KType, VType>
   /**
    * A view of the keys inside this map.
    */
-  final class KeysContainer extends AbstractKTypeCollection<KType>
+  public final class KeysContainer extends AbstractKTypeCollection<KType>
           implements KTypeLookupContainer<KType> {
     @Override
     public boolean contains(KType e) {

--- a/hppc/src/test/java/com/carrotsearch/hppc/expectations/APIExpectationsTest.java
+++ b/hppc/src/test/java/com/carrotsearch/hppc/expectations/APIExpectationsTest.java
@@ -7,10 +7,27 @@
  * Refer to the full license file "LICENSE.txt":
  * https://github.com/carrotsearch/hppc/blob/master/LICENSE.txt
  */
-package com.carrotsearch.hppc;
+package com.carrotsearch.hppc.expectations;
 
-import static com.carrotsearch.hppc.TestUtils.*;
+import static com.carrotsearch.hppc.TestUtils.assertEquals2;
 
+import com.carrotsearch.hppc.IntArrayDeque;
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntHashSet;
+import com.carrotsearch.hppc.IntIntHashMap;
+import com.carrotsearch.hppc.IntLongHashMap;
+import com.carrotsearch.hppc.IntLookupContainer;
+import com.carrotsearch.hppc.IntObjectHashMap;
+import com.carrotsearch.hppc.IntStack;
+import com.carrotsearch.hppc.LongCollection;
+import com.carrotsearch.hppc.ObjectArrayDeque;
+import com.carrotsearch.hppc.ObjectArrayList;
+import com.carrotsearch.hppc.ObjectCollection;
+import com.carrotsearch.hppc.ObjectHashSet;
+import com.carrotsearch.hppc.ObjectIntHashMap;
+import com.carrotsearch.hppc.ObjectLookupContainer;
+import com.carrotsearch.hppc.ObjectObjectHashMap;
+import com.carrotsearch.hppc.ObjectStack;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.annotations.SuppressForbidden;
 import org.assertj.core.api.Assertions;
@@ -82,8 +99,8 @@ public class APIExpectationsTest extends RandomizedTest {
     ObjectArrayList<Integer> l1 = new ObjectArrayList<Integer>();
     ObjectArrayList<Number> l2 = new ObjectArrayList<Number>();
 
-    Assertions.assertThat(l1.equalElements(l2)).isTrue();
-    Assertions.assertThat(l2.equalElements(l1)).isTrue();
+    Assertions.assertThat(l1.equals(l2)).isTrue();
+    Assertions.assertThat(l2.equals(l1)).isTrue();
   }
 
   @SuppressForbidden("new Integer() intentional.")
@@ -107,8 +124,8 @@ public class APIExpectationsTest extends RandomizedTest {
 
     Assertions.assertThat(l1.hashCode()).isEqualTo(l2.hashCode());
     Assertions.assertThat(l1.hashCode()).isEqualTo(l3.hashCode());
-    Assertions.assertThat(l1.equalElements(l2)).isTrue();
-    Assertions.assertThat(l1.equalElements(l3)).isFalse();
+    Assertions.assertThat(l1.equals(l2)).isTrue();
+    Assertions.assertThat(l1.equals(l3)).isFalse();
   }
 
   @SuppressForbidden("new Integer() intentional.")
@@ -132,8 +149,8 @@ public class APIExpectationsTest extends RandomizedTest {
 
     Assertions.assertThat(l1.hashCode()).isEqualTo(l2.hashCode());
     Assertions.assertThat(l1.hashCode()).isEqualTo(l3.hashCode());
-    Assertions.assertThat(l1.equalElements(l2)).isTrue();
-    Assertions.assertThat(l1.equalElements(l3)).isFalse();
+    Assertions.assertThat(l1.equals(l2)).isTrue();
+    Assertions.assertThat(l1.equals(l3)).isFalse();
   }
 
   @Test
@@ -216,6 +233,22 @@ public class APIExpectationsTest extends RandomizedTest {
     assertEquals2(1, map.putOrAdd(k1, 1, 2));
     Assertions.assertThat(map.containsKey(k1b)).isTrue();
     assertEquals2(3, map.putOrAdd(k1b, 1, 2));
+  }
+
+  @Test
+  public void keysValuesContainerVisibilityPrimitive() {
+    IntLookupContainer keys = new IntLongHashMap().keys();
+    LongCollection values = new IntLongHashMap().values();
+    Assertions.assertThat(keys).isNotNull();
+    Assertions.assertThat(values).isNotNull();
+  }
+
+  @Test
+  public void keysValuesContainerVisibilityGeneric() {
+    ObjectLookupContainer<Integer> keys = new ObjectObjectHashMap<Integer, Long>().keys();
+    ObjectCollection<Long> values = new ObjectObjectHashMap<Integer, Long>().values();
+    Assertions.assertThat(keys).isNotNull();
+    Assertions.assertThat(values).isNotNull();
   }
 
   /*


### PR DESCRIPTION
To add a test, I modified HppcExample_004_IteratingOverMaps to also use a WormMap.
I don't know if it is too specific for a simple high-level example. Maybe there is another test to verify the public visibility?