### PR TITLE
Support indexRemove in KTypeVTypeHashMap,KTypeHashSet,KTypeWormSet.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@
 
 ** New features and API changes
 
+   GH-24: Support indexRemove in KTypeVTypeHashMap,KTypeHashSet,KTypeWormSet (Bruno Roustant).
+
    GH-20: KeysContainer of WormMap is not public (Haoyu Zhai, Bruno Roustant).
 
    GH-13: Add automatic module name to the generated JAR's manifest ("com.carrotsearch.hppc")

--- a/hppc/src/main/java/com/carrotsearch/hppc/WormUtil.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/WormUtil.java
@@ -141,7 +141,10 @@ class WormUtil {
    *
    * @param index The index of an entry in the chain.
    * @param nextOffset next[index].
-   * @return The index of the last entry in the chain.
+   * @param returnPrevious Whether to return the entry before the last.
+   * @return The index of the last entry in the chain, or the entry before, depending on {@code
+   *     returnPrevious}. Returns {@code -1} if the entry at index is the last entry of the chain
+   *     and {@code returnPrevious} is true.
    */
   static int findLastOfChain(int index, int nextOffset, boolean returnPrevious, byte[] next) {
     assert checkIndex(index, next.length);
@@ -153,7 +156,7 @@ class WormUtil {
     if (nextOffset < 0) {
       nextOffset = -nextOffset;
     }
-    int previousIndex = Integer.MAX_VALUE;
+    int previousIndex = -1;
     while (nextOffset != END_OF_CHAIN) {
       previousIndex = index;
       index = addOffset(index, nextOffset, capacity); // Jump forward.

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeHashSet.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeHashSet.java
@@ -735,6 +735,27 @@ public class KTypeHashSet<KType>
     }
   }
 
+  /**
+   * Removes a key.
+   *
+   * @see #indexOf
+   *
+   * @param index The index of the key to remove, as returned from {@link #indexOf}.
+   * @throws AssertionError If assertions are enabled and the index does
+   *         not correspond to an existing key.
+   */
+  public void indexRemove(int index) {
+    assert index >= 0 : "The index must point at an existing key.";
+    assert index <= mask ||
+            (index == mask + 1 && hasEmptyKey);
+
+    if (index > mask) {
+      hasEmptyKey = false;
+    } else {
+      shiftConflictingKeys(index);
+    }
+  }
+
   @Override
   public String visualizeKeyDistribution(int characters) {
     return KTypeBufferVisualizer.visualizeKeyDistribution(keys, mask, characters);

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeHashSet.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeHashSet.java
@@ -736,7 +736,7 @@ public class KTypeHashSet<KType>
   }
 
   /**
-   * Removes a key.
+   * Removes a key at an index previously acquired from {@link #indexOf}.
    *
    * @see #indexOf
    *

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
@@ -537,6 +537,25 @@ public class KTypeVTypeHashMap<KType, VType>
    * {@inheritDoc}
    */
   @Override
+  public VType indexRemove(int index) {
+    assert index >= 0 : "The index must point at an existing key.";
+    assert index <= mask ||
+            (index == mask + 1 && hasEmptyKey);
+
+    VType previousValue = Intrinsics.<VType> cast(values[index]);
+    if (index > mask) {
+      hasEmptyKey = false;
+      values[index] = Intrinsics.<VType> empty();
+    } else {
+      shiftConflictingKeys(index);
+    }
+    return previousValue;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   public void clear() {
     assigned = 0;
     hasEmptyKey = false;

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeMap.java
@@ -189,7 +189,7 @@ public interface KTypeVTypeMap<KType, VType> extends KTypeVTypeAssociativeContai
   public void indexInsert(int index, KType key, VType value);
 
   /**
-   * Removes a key-value pair.
+   * Removes a key-value pair at an index previously acquired from {@link #indexOf}.
    *
    * @see #indexOf
    *

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeMap.java
@@ -189,6 +189,20 @@ public interface KTypeVTypeMap<KType, VType> extends KTypeVTypeAssociativeContai
   public void indexInsert(int index, KType key, VType value);
 
   /**
+   * Removes a key-value pair.
+   *
+   * @see #indexOf
+   *
+   * @param index
+   *          The index of the key to remove, as returned from {@link #indexOf}.
+   * @return Returns the previous value associated with the key.
+   * @throws AssertionError
+   *           If assertions are enabled and the index does not correspond to an
+   *           existing key.
+   */
+  public VType indexRemove(int index);
+
+  /**
    * Clear all keys and values in the container.
    * 
    * @see #release()

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeWormMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeWormMap.java
@@ -261,7 +261,7 @@ public class KTypeVTypeWormMap<KType, VType>
     }
     int entryToRemoveIndex = previousEntryIndex == Integer.MAX_VALUE ?
             hashIndex : addOffset(previousEntryIndex, Math.abs(next[previousEntryIndex]), next.length);
-    return remove(hashIndex, previousEntryIndex, entryToRemoveIndex);
+    return remove(entryToRemoveIndex, previousEntryIndex);
   }
 
   /** {@inheritDoc} */
@@ -505,6 +505,7 @@ public class KTypeVTypeWormMap<KType, VType>
   @Override
   public VType indexGet(int index) {
     assert checkIndex(index, next.length);
+    assert next[index] != 0;
     return Intrinsics.<VType>cast(values[index]);
   }
 
@@ -512,6 +513,7 @@ public class KTypeVTypeWormMap<KType, VType>
   @Override
   public VType indexReplace(int index, VType newValue) {
     assert checkIndex(index, next.length);
+    assert next[index] != 0;
     VType previousValue = Intrinsics.<VType>cast(values[index]);
     values[index] = newValue;
     return previousValue;
@@ -530,6 +532,14 @@ public class KTypeVTypeWormMap<KType, VType>
     } else {
       put(key, value, PutPolicy.NEW_GUARANTEED, true);
     }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public VType indexRemove(int index) {
+    assert checkIndex(index, next.length);
+    assert next[index] != 0;
+    return remove(index, Integer.MAX_VALUE);
   }
 
   /** {@inheritDoc} */
@@ -705,40 +715,42 @@ public class KTypeVTypeWormMap<KType, VType>
    * Removes the entry at the specified removal index.
    * Decrements {@link #size}.
    *
-   * @param headIndex          The head-of-chain index.
-   * @param previousEntryIndex The index of the entry in the chain preceding the entry to remove; or
-   *                           {@link Integer#MAX_VALUE} if the entry to remove is the head-of-chain.
    * @param entryToRemoveIndex The index of the entry to remove.
+   * @param previousEntryIndex The index of the entry in the chain preceding the entry to remove; or
+   *                           {@link Integer#MAX_VALUE} if unknown or if the entry to remove is the head-of-chain.
    * @return The value of the removed entry.
    */
-  private VType remove(int headIndex, int previousEntryIndex, int entryToRemoveIndex) {
-    assert checkIndex(headIndex, next.length);
-    assert next[headIndex] > 0;
-    assert previousEntryIndex == Integer.MAX_VALUE || checkIndex(previousEntryIndex, next.length);
+  private VType remove(int entryToRemoveIndex, int previousEntryIndex) {
     assert checkIndex(entryToRemoveIndex, next.length);
+    assert previousEntryIndex == Integer.MAX_VALUE || checkIndex(previousEntryIndex, next.length);
 
     final byte[] next = this.next;
     VType previousValue = Intrinsics.<VType>cast(values[entryToRemoveIndex]);
 
     // Find the last entry of the chain.
-    int beforeLastIndex = findLastOfChain(entryToRemoveIndex, next[entryToRemoveIndex], true, next);
-    int lastIndex;
-    if (beforeLastIndex == Integer.MAX_VALUE) {
-      beforeLastIndex = previousEntryIndex;
-      lastIndex = entryToRemoveIndex;
-    } else {
-      lastIndex = addOffset(beforeLastIndex, Math.abs(next[beforeLastIndex]), next.length);
-    }
-
     // Replace the removed entry by the last entry of the chain.
-    if (entryToRemoveIndex != lastIndex) {
-      // Removing an entry before the last of the chain. Replace it by the last one.
+    int nextOffset = next[entryToRemoveIndex];
+    int beforeLastIndex = findLastOfChain(entryToRemoveIndex, nextOffset, true, next);
+    int lastIndex;
+    if (beforeLastIndex == -1) {
+      // The entry to remove is the last of the chain.
+      lastIndex = entryToRemoveIndex;
+      if (nextOffset < 0) {
+        // Removing the last entry in a chain of at least two entries.
+        beforeLastIndex = previousEntryIndex == Integer.MAX_VALUE ?
+                findPreviousInChain(entryToRemoveIndex, next) : previousEntryIndex;
+        // Unlink the last entry which replaces the removed entry.
+        next[beforeLastIndex] = (byte) (next[beforeLastIndex] > 0 ? END_OF_CHAIN : -END_OF_CHAIN);
+      }
+    } else {
+      int beforeLastNextOffset = next[beforeLastIndex];
+      lastIndex = addOffset(beforeLastIndex, Math.abs(beforeLastNextOffset), next.length);
+      assert entryToRemoveIndex != lastIndex;
+      // The entry to remove is before the last of the chain. Replace it by the last one.
       keys[entryToRemoveIndex] = keys[lastIndex];
       values[entryToRemoveIndex] = values[lastIndex];
-    }
-    if (lastIndex != headIndex) {
-      // Removing an entry in a chain of at least two entries. Unlink the last entry which replaces the removed entry.
-      next[beforeLastIndex] = (byte) (beforeLastIndex == headIndex ? END_OF_CHAIN : -END_OF_CHAIN);
+      // Unlink the last entry which replaces the removed entry.
+      next[beforeLastIndex] = (byte) (beforeLastNextOffset > 0 ? END_OF_CHAIN : -END_OF_CHAIN);
     }
     // Free the last entry of the chain.
     keys[lastIndex] = Intrinsics.<KType>empty();

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeWormSet.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeWormSet.java
@@ -507,7 +507,7 @@ public class KTypeWormSet<KType>
   }
 
   /**
-   * Removes a key.
+   * Removes a key at an index previously acquired from {@link #indexOf}.
    *
    * @see #indexOf
    *

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeWormSet.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeWormSet.java
@@ -230,7 +230,7 @@ public class KTypeWormSet<KType>
     }
     int entryToRemoveIndex = previousEntryIndex == Integer.MAX_VALUE ?
             hashIndex : addOffset(previousEntryIndex, Math.abs(next[previousEntryIndex]), next.length);
-    remove(hashIndex, previousEntryIndex, entryToRemoveIndex);
+    remove(entryToRemoveIndex, previousEntryIndex);
     return true;
   }
 
@@ -457,6 +457,7 @@ public class KTypeWormSet<KType>
    */
   public KType indexGet(int index) {
     assert checkIndex(index, next.length);
+    assert next[index] != 0;
     return Intrinsics.<KType>cast(keys[index]);
   }
 
@@ -475,6 +476,7 @@ public class KTypeWormSet<KType>
    */
   public KType indexReplace(int index, KType equivalentKey) {
     assert checkIndex(index, next.length);
+    assert next[index] != 0;
     assert Intrinsics.equals(this, keys[index], equivalentKey);
     KType previousKey = Intrinsics.<KType>cast(keys[index]);
     keys[index] = equivalentKey;
@@ -502,6 +504,21 @@ public class KTypeWormSet<KType>
     } else {
       add(key, true, true);
     }
+  }
+
+  /**
+   * Removes a key.
+   *
+   * @see #indexOf
+   *
+   * @param index The index of the key to remove, as returned from {@link #indexOf}.
+   * @throws AssertionError If assertions are enabled and the index does
+   *         not correspond to an existing key.
+   */
+  public void indexRemove(int index) {
+    assert checkIndex(index, next.length);
+    assert next[index] != 0;
+    remove(index, Integer.MAX_VALUE);
   }
 
   /** {@inheritDoc} */
@@ -665,37 +682,39 @@ public class KTypeWormSet<KType>
    * Removes the entry at the specified removal index.
    * Decrements {@link #size}.
    *
-   * @param headIndex          The head-of-chain index.
-   * @param previousEntryIndex The index of the entry in the chain preceding the entry to remove; or
-   *                           {@link Integer#MAX_VALUE} if the entry to remove is the head-of-chain.
    * @param entryToRemoveIndex The index of the entry to remove.
+   * @param previousEntryIndex The index of the entry in the chain preceding the entry to remove; or
+ *                             {@link Integer#MAX_VALUE} if unknown or if the entry to remove is the head-of-chain.
    */
-  private void remove(int headIndex, int previousEntryIndex, int entryToRemoveIndex) {
-    assert checkIndex(headIndex, next.length);
-    assert next[headIndex] > 0;
-    assert previousEntryIndex == Integer.MAX_VALUE || checkIndex(previousEntryIndex, next.length);
+  private void remove(int entryToRemoveIndex, int previousEntryIndex) {
     assert checkIndex(entryToRemoveIndex, next.length);
+    assert previousEntryIndex == Integer.MAX_VALUE || checkIndex(previousEntryIndex, next.length);
 
     final byte[] next = this.next;
 
     // Find the last entry of the chain.
-    int beforeLastIndex = findLastOfChain(entryToRemoveIndex, next[entryToRemoveIndex], true, next);
-    int lastIndex;
-    if (beforeLastIndex == Integer.MAX_VALUE) {
-      beforeLastIndex = previousEntryIndex;
-      lastIndex = entryToRemoveIndex;
-    } else {
-      lastIndex = addOffset(beforeLastIndex, Math.abs(next[beforeLastIndex]), next.length);
-    }
-
     // Replace the removed entry by the last entry of the chain.
-    if (entryToRemoveIndex != lastIndex) {
-      // Removing an entry before the last of the chain. Replace it by the last one.
+    int nextOffset = next[entryToRemoveIndex];
+    int beforeLastIndex = findLastOfChain(entryToRemoveIndex, nextOffset, true, next);
+    int lastIndex;
+    if (beforeLastIndex == -1) {
+      // The entry to remove is the last of the chain.
+      lastIndex = entryToRemoveIndex;
+      if (nextOffset < 0) {
+        // Removing the last entry in a chain of at least two entries.
+        beforeLastIndex = previousEntryIndex == Integer.MAX_VALUE ?
+                findPreviousInChain(entryToRemoveIndex, next) : previousEntryIndex;
+        // Unlink the last entry which replaces the removed entry.
+        next[beforeLastIndex] = (byte) (next[beforeLastIndex] > 0 ? END_OF_CHAIN : -END_OF_CHAIN);
+      }
+    } else {
+      int beforeLastNextOffset = next[beforeLastIndex];
+      lastIndex = addOffset(beforeLastIndex, Math.abs(beforeLastNextOffset), next.length);
+      assert entryToRemoveIndex != lastIndex;
+      // The entry to remove is before the last of the chain. Replace it by the last one.
       keys[entryToRemoveIndex] = keys[lastIndex];
-    }
-    if (lastIndex != headIndex) {
-      // Removing an entry in a chain of at least two entries. Unlink the last entry which replaces the removed entry.
-      next[beforeLastIndex] = (byte) (beforeLastIndex == headIndex ? END_OF_CHAIN : -END_OF_CHAIN);
+      // Unlink the last entry which replaces the removed entry.
+      next[beforeLastIndex] = (byte) (beforeLastNextOffset > 0 ? END_OF_CHAIN : -END_OF_CHAIN);
     }
     // Free the last entry of the chain.
     keys[lastIndex] = Intrinsics.<KType>empty();

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeHashSetTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeHashSetTest.java
@@ -84,6 +84,14 @@ public class KTypeHashSetTest<KType> extends AbstractKTypeTest<KType>
       set.indexInsert(set.indexOf(key2), key2);
       Assertions.assertThat(set.indexGet(set.indexOf(key2))).isEqualTo(key2);
       Assertions.assertThat(set.size()).isEqualTo(3);
+
+      set.indexRemove(set.indexOf(keyE));
+      Assertions.assertThat(set.size()).isEqualTo(2);
+      set.indexRemove(set.indexOf(key2));
+      Assertions.assertThat(set.size()).isEqualTo(1);
+      Assertions.assertThat(set.indexOf(keyE)).isNegative();
+      Assertions.assertThat(set.indexOf(key1)).isNotNegative();
+      Assertions.assertThat(set.indexOf(key2)).isNegative();
     }
 
     @Test

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeHashSetTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeHashSetTest.java
@@ -407,14 +407,32 @@ public class KTypeHashSetTest<KType> extends AbstractKTypeTest<KType>
 
                 if (rnd.nextBoolean())
                 {
+                    if (rnd.nextBoolean()) {
+                        int index = set.indexOf(cast(key));
+                        if (set.indexExists(index)) {
+                            set.indexReplace(index, cast(key));
+                        } else {
+                            set.indexInsert(index, cast(key));
+                        }
+                    } else {
+                        set.add(cast(key));
+                    }
                     other.add(cast(key));
-                    set.add(cast(key));
 
                     assertTrue(set.contains(cast(key)));
+                    assertTrue(set.indexExists(set.indexOf(cast(key))));
                 }
                 else
                 {
-                    assertEquals(other.remove(key), set.remove(cast(key)));
+                    assertEquals(other.contains(key), set.contains(cast(key)));
+                    boolean removed;
+                    if (set.contains(cast(key)) && rnd.nextBoolean()) {
+                        set.indexRemove(set.indexOf(cast(key)));
+                        removed = true;
+                    } else {
+                        removed = set.remove(cast(key));
+                    }
+                    assertEquals(other.remove(key), removed);
                 }
 
                 assertEquals(other.size(), set.size());

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeHashMapTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeHashMapTest.java
@@ -196,6 +196,14 @@ public class KTypeVTypeHashMapTest<KType, VType> extends AbstractKTypeTest<KType
       map.indexInsert(map.indexOf(key2), key2, value1);
       Assertions.assertThat(map.indexGet(map.indexOf(key2))).isEqualTo(value1);
       Assertions.assertThat(map.size()).isEqualTo(3);
+
+      Assertions.assertThat(map.indexRemove(map.indexOf(keyE))).isEqualTo(value3);
+      Assertions.assertThat(map.size()).isEqualTo(2);
+      Assertions.assertThat(map.indexRemove(map.indexOf(key2))).isEqualTo(value1);
+      Assertions.assertThat(map.size()).isEqualTo(1);
+      Assertions.assertThat(map.indexOf(keyE)).isNegative();
+      Assertions.assertThat(map.indexOf(key1)).isNotNegative();
+      Assertions.assertThat(map.indexOf(key2)).isNegative();
     }
 
     /* */

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeHashMapTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeHashMapTest.java
@@ -762,16 +762,32 @@ public class KTypeVTypeHashMapTest<KType, VType> extends AbstractKTypeTest<KType
 
                 if (rnd.nextBoolean())
                 {
-                    map.put(key, value);
-                    other.put(key, value);
+                    VType previousValue;
+                    if (rnd.nextBoolean()) {
+                        int index = map.indexOf(key);
+                        if (map.indexExists(index)) {
+                            previousValue = map.indexReplace(index, value);
+                        } else {
+                            map.indexInsert(index, key, value);
+                            previousValue = null;
+                        }
+                    } else {
+                        previousValue = map.put(key, value);
+                    }
+                    assertEquals(other.put(key, value), previousValue);
 
                     assertEquals(value, map.get(key));
+                    assertEquals(value, map.indexGet(map.indexOf(key)));
                     assertTrue(map.containsKey(key));
+                    assertTrue(map.indexExists(map.indexOf(key)));
                 }
                 else
                 {
                     assertEquals(other.containsKey(key), map.containsKey(key));
-                    assertEquals(other.remove(key), map.remove(key));
+                    VType previousValue = map.containsKey(key) && rnd.nextBoolean() ?
+                            map.indexRemove(map.indexOf(key))
+                            : map.remove(key);
+                    assertEquals(other.remove(key), previousValue);
                 }
 
                 assertEquals(other.size(), map.size());

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeWormMapTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeWormMapTest.java
@@ -667,16 +667,32 @@ public class KTypeVTypeWormMapTest<KType, VType> extends AbstractKTypeTest<KType
 
                 if (rnd.nextBoolean())
                 {
-                    map.put(key, value);
-                    other.put(key, value);
+                    VType previousValue;
+                    if (rnd.nextBoolean()) {
+                        int index = map.indexOf(key);
+                        if (map.indexExists(index)) {
+                            previousValue = map.indexReplace(index, value);
+                        } else {
+                            map.indexInsert(index, key, value);
+                            previousValue = null;
+                        }
+                    } else {
+                        previousValue = map.put(key, value);
+                    }
+                    assertEquals(other.put(key, value), previousValue);
 
                     assertEquals(value, map.get(key));
+                    assertEquals(value, map.indexGet(map.indexOf(key)));
                     assertTrue(map.containsKey(key));
+                    assertTrue(map.indexExists(map.indexOf(key)));
                 }
                 else
                 {
                     assertEquals(other.containsKey(key), map.containsKey(key));
-                    assertEquals(other.remove(key), map.remove(key));
+                    VType previousValue = map.containsKey(key) && rnd.nextBoolean() ?
+                            map.indexRemove(map.indexOf(key))
+                            : map.remove(key);
+                    assertEquals(other.remove(key), previousValue);
                 }
 
                 assertEquals(other.size(), map.size());

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeWormMapTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeWormMapTest.java
@@ -148,6 +148,14 @@ public class KTypeVTypeWormMapTest<KType, VType> extends AbstractKTypeTest<KType
       map.indexInsert(map.indexOf(key2), key2, value1);
       Assertions.assertThat(map.indexGet(map.indexOf(key2))).isEqualTo(value1);
       Assertions.assertThat(map.size()).isEqualTo(3);
+
+      Assertions.assertThat(map.indexRemove(map.indexOf(keyE))).isEqualTo(value3);
+      Assertions.assertThat(map.size()).isEqualTo(2);
+      Assertions.assertThat(map.indexRemove(map.indexOf(key2))).isEqualTo(value1);
+      Assertions.assertThat(map.size()).isEqualTo(1);
+      Assertions.assertThat(map.indexOf(keyE)).isNegative();
+      Assertions.assertThat(map.indexOf(key1)).isNotNegative();
+      Assertions.assertThat(map.indexOf(key2)).isNegative();
     }
 
     /* */

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeWormSetTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeWormSetTest.java
@@ -83,6 +83,14 @@ public class KTypeWormSetTest<KType> extends AbstractKTypeTest<KType>
       set.indexInsert(set.indexOf(key2), key2);
       Assertions.assertThat(set.indexGet(set.indexOf(key2))).isEqualTo(key2);
       Assertions.assertThat(set.size()).isEqualTo(3);
+
+      set.indexRemove(set.indexOf(keyE));
+      Assertions.assertThat(set.size()).isEqualTo(2);
+      set.indexRemove(set.indexOf(key2));
+      Assertions.assertThat(set.size()).isEqualTo(1);
+      Assertions.assertThat(set.indexOf(keyE)).isNegative();
+      Assertions.assertThat(set.indexOf(key1)).isNotNegative();
+      Assertions.assertThat(set.indexOf(key2)).isNegative();
     }
 
     @Test

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeWormSetTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeWormSetTest.java
@@ -359,14 +359,32 @@ public class KTypeWormSetTest<KType> extends AbstractKTypeTest<KType>
 
                 if (rnd.nextBoolean())
                 {
+                    if (rnd.nextBoolean()) {
+                        int index = set.indexOf(cast(key));
+                        if (set.indexExists(index)) {
+                            set.indexReplace(index, cast(key));
+                        } else {
+                            set.indexInsert(index, cast(key));
+                        }
+                    } else {
+                        set.add(cast(key));
+                    }
                     other.add(cast(key));
-                    set.add(cast(key));
 
                     assertTrue(set.contains(cast(key)));
+                    assertTrue(set.indexExists(set.indexOf(cast(key))));
                 }
                 else
                 {
-                    assertEquals(other.remove(key), set.remove(cast(key)));
+                    assertEquals(other.contains(key), set.contains(cast(key)));
+                    boolean removed;
+                    if (set.contains(cast(key)) && rnd.nextBoolean()) {
+                        set.indexRemove(set.indexOf(cast(key)));
+                        removed = true;
+                    } else {
+                        removed = set.remove(cast(key));
+                    }
+                    assertEquals(other.remove(key), removed);
                 }
 
                 assertEquals(other.size(), set.size());


### PR DESCRIPTION
New API method KTypeVTypeMap.indexRemove() + implementation in KTypeVTypeHashMap and KTypeVTypeWormMap.

New public method indexRemove() in KTypeHashSet and KTypeWormSet.

+ tests