### PR TITLE
Added Identity Short Circuit to equals methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@
 
    GH-25: Added addAll(KTypeContainer) on KTypeSet. (Erich Schubert, Dawid Weiss).
 
+   GH-27: Added identity short circuit to existing equals methods. (Callum Galbreath).
+
 ** Bugs
 
 

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayDeque.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayDeque.java
@@ -864,11 +864,12 @@ public class KTypeArrayDeque<KType>
 #end 
      */
   @Override
-  public boolean equals(Object obj)
-  {
-    return obj != null &&
-           getClass() == obj.getClass() &&
-           equalElements(getClass().cast(obj));
+  public boolean equals(Object obj) {
+    return (this == obj) || (
+      obj != null &&
+      getClass() == obj.getClass() &&
+      equalElements(getClass().cast(obj))
+    );
   }
 
   /**

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayList.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayList.java
@@ -482,9 +482,11 @@ public class KTypeArrayList<KType>
      */
   @Override
   public boolean equals(Object obj) {
-      return obj != null &&
-             getClass() == obj.getClass() &&
-             equalElements(getClass().cast(obj));
+    return (this == obj) || (
+      obj != null &&
+      getClass() == obj.getClass() &&
+      equalElements(getClass().cast(obj))
+    );
   }
 
   /**

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeHashSet.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeHashSet.java
@@ -410,9 +410,11 @@ public class KTypeHashSet<KType>
    */
   @Override
   public boolean equals(Object obj) {
-    return obj != null &&
-           getClass() == obj.getClass() &&
-           sameKeys(getClass().cast(obj));
+    return (this == obj) || (
+      obj != null &&
+      getClass() == obj.getClass() &&
+      sameKeys(getClass().cast(obj))
+    );
   }
 
   /**

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
@@ -613,9 +613,11 @@ public class KTypeVTypeHashMap<KType, VType>
    */
   @Override
   public boolean equals(Object obj) {
-    return obj != null &&
-           getClass() == obj.getClass() &&
-           equalElements(getClass().cast(obj));
+    return (this == obj) || (
+      obj != null &&
+      getClass() == obj.getClass() &&
+      equalElements(getClass().cast(obj))
+    );
   }
 
   /**

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeWormMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeWormMap.java
@@ -421,6 +421,9 @@ public class KTypeVTypeWormMap<KType, VType>
   @Override
   @SuppressWarnings("unchecked")
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeWormSet.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeWormSet.java
@@ -351,6 +351,9 @@ public class KTypeWormSet<KType>
   @Override
   @SuppressWarnings("unchecked")
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }


### PR DESCRIPTION
### Summary
* This is a micro optimisation for when `equals` is called with a reference to the same object
* This is to avoid having consumers of equals performing this check themselves

### Outstanding Concerns

Not sure how sensitive this code path will be to the extra branch. I would guess that it's fairly branch predictor friendly.

