### PR TITLE
Add in-place QuickSort and use it in SortedIterationKTypeVTypeHashMap.

### DIFF
--- a/hppc/src/main/java/com/carrotsearch/hppc/sorting/IndirectSort.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/sorting/IndirectSort.java
@@ -34,7 +34,8 @@ public final class IndirectSort {
    * Returns the order of elements between indices <code>start</code> and <code>length</code>, as
    * indicated by the given <code>comparator</code>.
    *
-   * <p>This routine uses merge sort. It is guaranteed to be stable.
+   * <p>This routine uses merge sort. It is guaranteed to be stable. It creates a new indices array,
+   * and clones it while sorting.
    */
   public static int[] mergesort(int start, int length, IntBinaryOperator comparator) {
     final int[] src = createOrderArray(start, length);
@@ -44,7 +45,8 @@ public final class IndirectSort {
   /**
    * Returns a sorted copy of the order array provided, using the given <code>comparator</code>.
    *
-   * <p>This routine uses merge sort. It is guaranteed to be stable.
+   * <p>This routine uses merge sort. It is guaranteed to be stable. The provided {@code
+   * indicesArray} is cloned while sorting and the clone is returned.
    */
   public static int[] mergesort(int[] orderArray, IntBinaryOperator comparator) {
     if (orderArray.length <= 1) {
@@ -59,7 +61,8 @@ public final class IndirectSort {
    * Returns the order of elements between indices <code>start</code> and <code>length</code>, as
    * indicated by the given <code>comparator</code>.
    *
-   * <p>This routine uses merge sort. It is guaranteed to be stable.
+   * <p>This routine uses merge sort. It is guaranteed to be stable. It creates a new indices array,
+   * and clones it while sorting.
    */
   public static <T> int[] mergesort(
       T[] input, int start, int length, Comparator<? super T> comparator) {

--- a/hppc/src/main/java/com/carrotsearch/hppc/sorting/QuickSort.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/sorting/QuickSort.java
@@ -1,0 +1,165 @@
+/*
+ * HPPC
+ *
+ * Copyright (C) 2010-2020 Carrot Search s.c.
+ * All rights reserved.
+ *
+ * Refer to the full license file "LICENSE.txt":
+ * https://github.com/carrotsearch/hppc/blob/master/LICENSE.txt
+ */
+package com.carrotsearch.hppc.sorting;
+
+import java.util.function.IntBinaryOperator;
+
+/**
+ * In-place Quick sort with 3-way partitioning and ending with Insertion sort.
+ *
+ * <p>The sorting is not stable. Performance is O(n.log(n)) and memory is O(1) (although recursion
+ * memory is O(log(n))).
+ */
+public final class QuickSort {
+
+  /** Below this size threshold, the sub-range is sorted using Insertion sort. */
+  static final int INSERTION_SORT_THRESHOLD = 10;
+
+  /** Below this size threshold, the partition selection is simplified to a single median. */
+  static final int SINGLE_MEDIAN_THRESHOLD = 50;
+
+  /** No instantiation. */
+  private QuickSort() {
+    // No instantiation.
+  }
+
+  /** @see #sort(int, int, IntBinaryOperator, IntBinaryOperator) */
+  public static void sort(int[] array, IntBinaryOperator comparator) {
+    sort(array, 0, array.length, comparator);
+  }
+
+  /** @see #sort(int, int, IntBinaryOperator, IntBinaryOperator) */
+  public static void sort(int[] array, int fromIndex, int toIndex, IntBinaryOperator comparator) {
+    sort(
+        fromIndex,
+        toIndex,
+        comparator,
+        (i, j) -> {
+          int swap = array[i];
+          array[i] = array[j];
+          array[j] = swap;
+          return 0;
+        });
+  }
+
+  /**
+   * Performs a recursive in-place Quick sort. The sorting is not stable.
+   *
+   * @param fromIndex Index where to start sorting in the array, inclusive.
+   * @param toIndex Index where to stop sorting in the array, exclusive.
+   * @param comparator Compares elements based on their indices. Given indices i and j in the
+   *     provided array, this comparator returns respectively -1/0/1 if the element at index i is
+   *     respectively less/equal/greater than the element at index j.
+   * @param swapper Swaps the elements in the array at the given indices. For example, a custom
+   *     swapper may allow sorting two arrays simultaneously.
+   */
+  public static void sort(
+      int fromIndex, int toIndex, IntBinaryOperator comparator, IntBinaryOperator swapper) {
+    sortInner(fromIndex, toIndex - 1, comparator, swapper);
+  }
+
+  /**
+   * @param start Start index, inclusive.
+   * @param end End index, inclusive.
+   * @param c Compares elements based on their indices.
+   * @param s Swaps the elements in the array at the given indices.
+   */
+  private static void sortInner(
+      final int start, final int end, IntBinaryOperator c, IntBinaryOperator s) {
+    final int size = end - start + 1;
+    final int middle = start + size >> 1;
+
+    if (size <= INSERTION_SORT_THRESHOLD) {
+      insertionSort(start, end, c, s);
+      return;
+    }
+
+    int median;
+    if (size <= SINGLE_MEDIAN_THRESHOLD) {
+      // Select the partition with a single median.
+      median = median(start, middle, end, c);
+    } else {
+      // Select the partition with the median of medians.
+      int range = size >> 3;
+      int doubleRange = range << 1;
+      int medianStart = median(start, start + range, start + doubleRange, c);
+      int medianMiddle = median(middle - range, middle, middle + range, c);
+      int medianEnd = median(end - doubleRange, end - range, end, c);
+      median = median(medianStart, medianMiddle, medianEnd, c);
+    }
+    swap(start, median, s);
+
+    // 3-way partitioning.
+    int i = start;
+    int j = end + 1;
+    int p = start + 1;
+    int q = end;
+    while (true) {
+      while (++i < end && comp(i, start, c) < 0) ;
+      while (--j > start && comp(j, start, c) > 0) ;
+      if (i >= j) {
+        if (i == j && comp(i, start, c) == 0) {
+          swap(i, p, s);
+        }
+        break;
+      }
+      swap(i, j, s);
+      if (comp(i, start, c) == 0) {
+        swap(i, p++, s);
+      }
+      if (comp(j, start, c) == 0) {
+        swap(j, q--, s);
+      }
+    }
+    i = j + 1;
+    for (int k = start; k < p; k++) {
+      swap(k, j--, s);
+    }
+    for (int k = end; k > q; k--) {
+      swap(k, i++, s);
+    }
+
+    sortInner(start, j, c, s);
+    sortInner(i, end, c, s);
+  }
+
+  /** Sorts from start to end indices inclusive with insertion sort. */
+  private static void insertionSort(int start, int end, IntBinaryOperator c, IntBinaryOperator s) {
+    for (int i = start + 1; i <= end; i++) {
+      for (int j = i; j > start && comp(j - 1, j, c) > 0; j--) {
+        swap(j - 1, j, s);
+      }
+    }
+  }
+
+  /** Returns the index of the median element among three elements at provided indices. */
+  private static int median(int i, int j, int k, IntBinaryOperator c) {
+    if (comp(i, j, c) < 0) {
+      if (comp(j, k, c) <= 0) {
+        return j;
+      }
+      return comp(i, k, c) < 0 ? k : i;
+    }
+    if (comp(j, k, c) >= 0) {
+      return j;
+    }
+    return comp(i, k, c) < 0 ? i : k;
+  }
+
+  /** Compares two elements at provided indices. */
+  private static int comp(int i, int j, IntBinaryOperator comparator) {
+    return comparator.applyAsInt(i, j);
+  }
+
+  /** Swaps two elements at provided indices. */
+  private static void swap(int i, int j, IntBinaryOperator swapper) {
+    swapper.applyAsInt(i, j);
+  }
+}

--- a/hppc/src/main/templates/com/carrotsearch/hppc/SortedIterationKTypeVTypeHashMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/SortedIterationKTypeVTypeHashMap.java
@@ -5,7 +5,7 @@ import com.carrotsearch.hppc.comparators.*;
 import com.carrotsearch.hppc.cursors.*;
 import com.carrotsearch.hppc.predicates.*;
 import com.carrotsearch.hppc.procedures.*;
-import com.carrotsearch.hppc.sorting.IndirectSort;
+import com.carrotsearch.hppc.sorting.QuickSort;
 
 /*! #if ($TemplateOptions.KTypeGeneric) !*/
 import java.util.Comparator;
@@ -79,24 +79,28 @@ public class SortedIterationKTypeVTypeHashMap<KType, VType>
   protected int[] sortIterationOrder(int[] entryIndexes,
       /*! #if ($TemplateOptions.KTypeGeneric) !*/ Comparator<KType> /*! #else KTypeComparator<KType> #end !*/ comparator
   ) {
-    return IndirectSort.mergesort(entryIndexes, (a, b) -> {
+    QuickSort.sort(entryIndexes, (i, j) -> {
       KType[] keys = Intrinsics.<KType[]> cast(delegate.keys);
-      return comparator.compare(keys[a], keys[b]);
+      return comparator.compare(keys[entryIndexes[i]], keys[entryIndexes[j]]);
     });
+    return entryIndexes;
   }
 
   /**
    * Sort the iteration order array based on the provided comparator on keys and values.
    */
   protected int[] sortIterationOrder(int[] entryIndexes, KTypeVTypeComparator<KType, VType> comparator) {
-    return IndirectSort.mergesort(entryIndexes, new IntBinaryOperator() {
+    QuickSort.sort(entryIndexes, new IntBinaryOperator() {
       final KType[] keys = Intrinsics.<KType[]> cast(delegate.keys);
       final VType[] values = Intrinsics.<VType[]> cast(delegate.values);
       @Override
-      public int applyAsInt(int a, int b) {
-        return comparator.compare(keys[a], values[a], keys[b], values[b]);
+      public int applyAsInt(int i, int j) {
+        int index1 = entryIndexes[i];
+        int index2 = entryIndexes[j];
+        return comparator.compare(keys[index1], values[index1], keys[index2], values[index2]);
       }
     });
+    return entryIndexes;
   }
 
   @Override

--- a/hppc/src/test/java/com/carrotsearch/hppc/sorting/IndirectSortTest.java
+++ b/hppc/src/test/java/com/carrotsearch/hppc/sorting/IndirectSortTest.java
@@ -9,153 +9,18 @@
  */
 package com.carrotsearch.hppc.sorting;
 
-import static org.junit.Assert.*;
+import static com.carrotsearch.hppc.sorting.SortTest.assertOrder;
+import static org.junit.Assert.assertTrue;
 
 import com.carrotsearch.hppc.XorShift128P;
-import java.util.Arrays;
 import java.util.Random;
 import java.util.function.IntBinaryOperator;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Test;
 
 /** Test cases for {@link IndirectSort}. */
 public class IndirectSortTest {
-  static final int DATA_LENGTH = 1000000;
-
-  /** Implies the same order as the order of indices. */
-  private static class OrderedInputComparator implements IntBinaryOperator {
-    @Override
-    public int applyAsInt(int a, int b) {
-      return Integer.compare(a, b);
-    }
-  }
-
-  /** Implies reverse order of indices. */
-  private static class ReverseOrderedInputComparator implements IntBinaryOperator {
-    @Override
-    public int applyAsInt(int a, int b) {
-      return -Integer.compare(a, b);
-    }
-  }
-
-  enum DataDistribution {
-    ORDERED,
-    SAWTOOTH,
-    RANDOM,
-    STAGGER,
-    PLATEAU,
-    SHUFFLE
-  }
-
-  enum Algorithm {
-    MERGESORT
-  }
-
-  /** Test "certification" program as in Bentley and McIlroy's paper. */
-  @Test
-  public void testSortCertificationMergeSort() {
-    sortCertification(Algorithm.MERGESORT);
-  }
-
-  /** Run a "sort certification" test. */
-  static void sortCertification(Algorithm algorithm) {
-    int[] n_values = {100, 1023, 1024, 1025, 1024 * 32};
-
-    for (int n : n_values) {
-      for (int m = 1; m < 2 * n; m *= 2) {
-        for (DataDistribution dist : DataDistribution.values()) {
-          int[] x = generate(dist, n, m);
-
-          String testName = dist + "-" + n + "-" + m;
-          testOn(algorithm, x, testName + "-normal");
-          testOn(algorithm, reverse(x, 0, n), testName + "-reversed");
-          testOn(algorithm, reverse(x, 0, n / 2), testName + "-reversed_front");
-          testOn(algorithm, reverse(x, n / 2, n), testName + "-reversed_back");
-          testOn(algorithm, sort(x), testName + "-sorted");
-          testOn(algorithm, dither(x), testName + "-dither");
-        }
-      }
-    }
-  }
-
-  /**
-   * Generate <code>n</code>-length data set distributed according to <code>dist</code>.
-   *
-   * @param m Step for sawtooth, stagger, plateau and shuffle.
-   */
-  static int[] generate(final DataDistribution dist, int n, int m) {
-    // Start from a constant seed (repeatable tests).
-    final Random rand = new Random(0x11223344);
-    final int[] x = new int[n];
-    for (int i = 0, j = 0, k = 1; i < n; i++) {
-      switch (dist) {
-        case ORDERED:
-          x[i] = i;
-          break;
-        case SAWTOOTH:
-          x[i] = i % m;
-          break;
-        case RANDOM:
-          x[i] = rand.nextInt() % m;
-          break;
-        case STAGGER:
-          x[i] = (i * m + i) % n;
-          break;
-        case PLATEAU:
-          x[i] = Math.min(i, m);
-          break;
-        case SHUFFLE:
-          x[i] = (rand.nextInt() % m) != 0 ? (j += 2) : (k += 2);
-          break;
-        default:
-          throw new RuntimeException();
-      }
-    }
-
-    return x;
-  }
-
-  static int[] sort(int[] x) {
-    x = copy(x);
-    Arrays.sort(x);
-    return x;
-  }
-
-  static int[] dither(int[] x) {
-    x = copy(x);
-    for (int i = 0; i < x.length; i++) x[i] += i % 5;
-    return x;
-  }
-
-  static int[] reverse(int[] x, int start, int end) {
-    x = copy(x);
-    for (int i = start, j = end - 1; i < j; i++, j--) {
-      int v = x[i];
-      x[i] = x[j];
-      x[j] = v;
-    }
-    return x;
-  }
-
-  private static int[] copy(int[] x) {
-    return (int[]) x.clone();
-  }
-
-  /*
-   *
-   */
-  private static void testOn(Algorithm algo, int[] x, String testName) {
-    final int[] order;
-    switch (algo) {
-      case MERGESORT:
-        order = IndirectSort.mergesort(0, x.length, Integer::compare);
-        break;
-      default:
-        Assert.fail();
-        throw new RuntimeException();
-    }
-
-    assertOrder(order, x.length, Integer::compare);
-  }
+  private static final int DATA_LENGTH = 1000000;
 
   /** Empty and single-item input. */
   @Test
@@ -174,16 +39,6 @@ public class IndirectSortTest {
   public void testOrderedMergeSort() {
     int[] order = IndirectSort.mergesort(0, DATA_LENGTH, Integer::compare);
     assertOrder(order, DATA_LENGTH, Integer::compare);
-  }
-
-  /*
-   *
-   */
-  private static void assertOrder(
-      final int[] order, int length, final IntBinaryOperator comparator) {
-    for (int i = 1; i < length; i++) {
-      Assert.assertTrue(comparator.applyAsInt(order[i - 1], order[i]) <= 0);
-    }
   }
 
   /** Randomized input, ascending int comparator. */
@@ -250,9 +105,6 @@ public class IndirectSortTest {
     }
   }
 
-  /*
-   *
-   */
   private int[] generateRandom(final int maxSize, final int vocabulary, final Random rnd) {
     final int[] input = new int[2 + rnd.nextInt(maxSize)];
     for (int i = 0; i < input.length; i++) {
@@ -261,9 +113,6 @@ public class IndirectSortTest {
     return input;
   }
 
-  /*
-   *
-   */
   private double[] generateRandom(final int maxSize, final Random rnd) {
     final double[] input = new double[2 + rnd.nextInt(maxSize)];
     for (int i = 0; i < input.length; i++) {

--- a/hppc/src/test/java/com/carrotsearch/hppc/sorting/SortTest.java
+++ b/hppc/src/test/java/com/carrotsearch/hppc/sorting/SortTest.java
@@ -1,0 +1,168 @@
+/*
+ * HPPC
+ *
+ * Copyright (C) 2010-2020 Carrot Search s.c.
+ * All rights reserved.
+ *
+ * Refer to the full license file "LICENSE.txt":
+ * https://github.com/carrotsearch/hppc/blob/master/LICENSE.txt
+ */
+package com.carrotsearch.hppc.sorting;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.function.IntBinaryOperator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SortTest {
+
+  enum DataDistribution {
+    ORDERED,
+    SAWTOOTH,
+    RANDOM,
+    STAGGER,
+    PLATEAU,
+    SHUFFLE
+  }
+
+  enum Algorithm {
+    INDIRECT_MERGESORT(
+        x -> {
+          IntBinaryOperator comparator = (i, j) -> Integer.compare(x[i], x[j]);
+          int[] order = IndirectSort.mergesort(0, x.length, comparator);
+          assertOrder(order, x.length, comparator);
+        }),
+    QUICKSORT(
+        x -> {
+          IntBinaryOperator comparator = (i, j) -> Integer.compare(x[i], x[j]);
+          QuickSort.sort(x, comparator);
+          assertOrder(x, x.length, Integer::compare);
+        }),
+    ;
+    private final Tester tester;
+
+    Algorithm(Tester tester) {
+      this.tester = tester;
+    }
+
+    void test(int[] x) {
+      tester.test(copy(x));
+    }
+
+    private interface Tester {
+      void test(int[] x);
+    }
+  }
+
+  @Test
+  public void testSortCertificationIndirectMergeSort() {
+    sortCertification(Algorithm.INDIRECT_MERGESORT);
+  }
+
+  @Test
+  public void testSortCertificationQuickSort() {
+    sortCertification(Algorithm.QUICKSORT);
+  }
+
+  /** Run a "sort certification" test as in Bentley and McIlroy's paper. */
+  private static void sortCertification(Algorithm algorithm) {
+    int[] n_values = {100, 1023, 1024, 1025, 1024 * 32};
+
+    long startTimeNs = System.nanoTime();
+    for (int n : n_values) {
+      for (int m = 1; m < 2 * n; m *= 2) {
+        for (DataDistribution dist : DataDistribution.values()) {
+          int[] x = generate(dist, n, m);
+
+          String testName = dist + "-" + n + "-" + m;
+          testOn(algorithm, x, testName + "-normal");
+          testOn(algorithm, reverse(x, 0, n), testName + "-reversed");
+          testOn(algorithm, reverse(x, 0, n / 2), testName + "-reversed_front");
+          testOn(algorithm, reverse(x, n / 2, n), testName + "-reversed_back");
+          testOn(algorithm, sort(x), testName + "-sorted");
+          testOn(algorithm, dither(x), testName + "-dither");
+        }
+      }
+    }
+    long timeNs = System.nanoTime() - startTimeNs;
+    System.out.println(algorithm + " time = " + timeNs + " ns");
+  }
+
+  /**
+   * Generate <code>n</code>-length data set distributed according to <code>dist</code>.
+   *
+   * @param m Step for sawtooth, stagger, plateau and shuffle.
+   */
+  private static int[] generate(final DataDistribution dist, int n, int m) {
+    // Start from a constant seed (repeatable tests).
+    final Random rand = new Random(0x11223344);
+    final int[] x = new int[n];
+    for (int i = 0, j = 0, k = 1; i < n; i++) {
+      switch (dist) {
+        case ORDERED:
+          x[i] = i;
+          break;
+        case SAWTOOTH:
+          x[i] = i % m;
+          break;
+        case RANDOM:
+          x[i] = rand.nextInt() % m;
+          break;
+        case STAGGER:
+          x[i] = (i * m + i) % n;
+          break;
+        case PLATEAU:
+          x[i] = Math.min(i, m);
+          break;
+        case SHUFFLE:
+          x[i] = (rand.nextInt() % m) != 0 ? (j += 2) : (k += 2);
+          break;
+        default:
+          throw new RuntimeException();
+      }
+    }
+
+    return x;
+  }
+
+  private static int[] sort(int[] x) {
+    x = copy(x);
+    Arrays.sort(x);
+    return x;
+  }
+
+  private static int[] dither(int[] x) {
+    x = copy(x);
+    for (int i = 0; i < x.length; i++) x[i] += i % 5;
+    return x;
+  }
+
+  private static int[] reverse(int[] x, int start, int end) {
+    x = copy(x);
+    for (int i = start, j = end - 1; i < j; i++, j--) {
+      int v = x[i];
+      x[i] = x[j];
+      x[j] = v;
+    }
+    return x;
+  }
+
+  private static int[] copy(int[] x) {
+    return x.clone();
+  }
+
+  private static void testOn(Algorithm algo, int[] x, String testName) {
+    try {
+      algo.test(x);
+    } catch (AssertionError e) {
+      throw new AssertionError(testName + " failed", e);
+    }
+  }
+
+  static void assertOrder(int[] order, int length, IntBinaryOperator comparator) {
+    for (int i = 1; i < length; i++) {
+      Assert.assertTrue(comparator.applyAsInt(order[i - 1], order[i]) <= 0);
+    }
+  }
+}


### PR DESCRIPTION
In the case of SortedIterationKTypeVTypeHashMap, we want to sort the key set of a delegate hash map. We know there are no duplicate keys, and they are randomly distributed, and we don't need to have a stable sort. Hence it is a good case to use an in-place Quick sort instead of IndirectSort merge sort (which needs a copy of the source array).

So with this change, SortedIterationKTypeVTypeHashMap sorts with in-place quick sort. It is faster and does not require a clone of the indices array anymore.

This new QuickSort implementation, with 3-way partitioning, works on a provided comparator and also a provided swapper.
- The comparator is different than the one in IndirectSort because it receives the indices of the elements to compare (not the value of the indirect indices-array). So it can be used for both direct and indirect sorting. (It is used for indirect sorting in SortedIterationKTypeVTypeHashMap, and for direct sorting in SortTest)
- The swapper interface has two benefits. It allows the sort implementation to not depend on the array type anymore. And it also allows the caller to provide a custom swapper, able for example to swap the elements of two arrays at the same time. (Useful when we have two simple arrays for keys and values and we sort the keys while the values follow, then we can do a binary search on the keys, very compact)

I extracted the sort certification code from IndirectSortTest to move it to a new SortTest, which now tests both IndirectSort and QuickSort.