### PR TITLE
Use FunctionalInterface where appropriate

### DIFF
--- a/hppc/src/main/templates/com/carrotsearch/hppc/comparators/KTypeComparator.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/comparators/KTypeComparator.java
@@ -5,6 +5,7 @@ package com.carrotsearch.hppc.comparators;
  * Compares two <code>KType</code> values.
  */
 /*! ${TemplateOptions.generatedAnnotation} !*/
+@FunctionalInterface
 public interface KTypeComparator<KType> {
   int compare(KType a, KType b);
 

--- a/hppc/src/main/templates/com/carrotsearch/hppc/comparators/KTypeVTypeComparator.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/comparators/KTypeVTypeComparator.java
@@ -4,6 +4,7 @@ package com.carrotsearch.hppc.comparators;
  * Compares two <code>KType</code>, <code>VType</code> pairs.
  */
 /*! ${TemplateOptions.generatedAnnotation} !*/
+@FunctionalInterface
 public interface KTypeVTypeComparator<KType, VType> {
   int compare(KType k1, VType v1, KType k2, VType v2);
 }

--- a/hppc/src/main/templates/com/carrotsearch/hppc/predicates/KTypePredicate.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/predicates/KTypePredicate.java
@@ -4,6 +4,7 @@ package com.carrotsearch.hppc.predicates;
  * A predicate that applies to <code>KType</code> objects.
  */
 /*! ${TemplateOptions.generatedAnnotation} !*/
+@FunctionalInterface
 public interface KTypePredicate<KType> {
   public boolean apply(KType value);
 }

--- a/hppc/src/main/templates/com/carrotsearch/hppc/predicates/KTypeVTypePredicate.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/predicates/KTypeVTypePredicate.java
@@ -4,6 +4,7 @@ package com.carrotsearch.hppc.predicates;
  * A predicate that applies to <code>KType</code>, <code>VType</code> pairs.
  */
 /*! ${TemplateOptions.generatedAnnotation} !*/
+@FunctionalInterface
 public interface KTypeVTypePredicate<KType, VType> {
   public boolean apply(KType key, VType value);
 }

--- a/hppc/src/main/templates/com/carrotsearch/hppc/procedures/KTypeProcedure.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/procedures/KTypeProcedure.java
@@ -4,6 +4,7 @@ package com.carrotsearch.hppc.procedures;
  * A procedure that applies to <code>KType</code> objects.
  */
 /*! ${TemplateOptions.generatedAnnotation} !*/
+@FunctionalInterface
 public interface KTypeProcedure<KType> {
   public void apply(KType value);
 }

--- a/hppc/src/main/templates/com/carrotsearch/hppc/procedures/KTypeVTypeProcedure.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/procedures/KTypeVTypeProcedure.java
@@ -4,6 +4,7 @@ package com.carrotsearch.hppc.procedures;
  * A procedure that applies to <code>KType</code>, <code>VType</code> pairs.
  */
 /*! ${TemplateOptions.generatedAnnotation} !*/
+@FunctionalInterface
 public interface KTypeVTypeProcedure<KType, VType> {
   public void apply(KType key, VType value);
 }


### PR DESCRIPTION
This would make the API nicer, as it allow lambda notation, as well as method handles.
Feel free to squash this pull into one commit, but I edited the files in github, and that committed one file at a time.

E.g. instead of
```java
list.forEach(new IntProcedure() {
	@Override
	public void apply(int value) {
		blackhole.consume(value);
	}
});
```
one could then write
```java
list.forEach(blackhole::consume);
```
or
```java
list.forEach(x -> blackhole.consume(x));
```
