### PR TITLE
Fix HashMap put/remove returned value for empty key after clear.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,11 +7,13 @@
           Those associative containers implementing Worm Hashing were added in HPPC-176.
           Since then, with improvements to HashMap, there is no clear advantage to using
           WormMap. Dropping them helps to reduce the library size.
-
           (Bruno Roustant).
 
 ** Improvements
 
+** Bugs
+
+  GH-237: Fix HashMap put/remove returned value for empty key after clear. (Bruno Roustant)
 
 [0.9.1]
 https://github.com/carrotsearch/hppc/releases/tag/0.9.1

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeHashSet.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeHashSet.java
@@ -11,8 +11,8 @@ import static com.carrotsearch.hppc.HashContainers.*;
 import static com.carrotsearch.hppc.Containers.*;
 
 /**
- * A hash set of <code>KType</code>s, implemented using using open addressing
- * with linear probing for collision resolution.
+ * A hash set of <code>KType</code>s, implemented using open addressing with
+ * linear probing for collision resolution.
  *
  * @see <a href="{@docRoot}/overview-summary.html#interfaces">HPPC interfaces diagram</a>
  */
@@ -656,7 +656,7 @@ public class KTypeHashSet<KType>
    */
   public boolean indexExists(int index) {
     assert index < 0 || 
-    (index >= 0 && index <= mask) ||
+    index <= mask ||
     (index == mask + 1 && hasEmptyKey);
 
     return index >= 0; 

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
@@ -131,8 +131,8 @@ public class KTypeVTypeHashMap<KType, VType>
 
     final int mask = this.mask;
     if (Intrinsics.<KType> isEmpty(key)) {
+      VType previousValue = hasEmptyKey ? Intrinsics.<VType> cast(values[mask + 1]) : Intrinsics.<VType> empty();
       hasEmptyKey = true;
-      VType previousValue = Intrinsics.<VType> cast(values[mask + 1]);
       values[mask + 1] = value;
       return previousValue;
     } else {
@@ -237,6 +237,9 @@ public class KTypeVTypeHashMap<KType, VType>
   public VType remove(KType key) {
     final int mask = this.mask;
     if (Intrinsics.<KType> isEmpty(key)) {
+      if (!hasEmptyKey) {
+        return Intrinsics.<VType> empty();
+      }
       hasEmptyKey = false;
       VType previousValue = Intrinsics.<VType> cast(values[mask + 1]);
       values[mask + 1] = Intrinsics.<VType> empty();
@@ -528,6 +531,7 @@ public class KTypeVTypeHashMap<KType, VType>
 
     VType previousValue = Intrinsics.<VType> cast(values[index]);
     if (index > mask) {
+      assert index == mask + 1;
       hasEmptyKey = false;
       values[index] = Intrinsics.<VType> empty();
     } else {


### PR DESCRIPTION
While finishing to test the small fork of HPPC in Lucene, I discovered a small bug in HashMap put and remove, in the returned value, after clear was called on the map. This is a edge case clearly, but I found a bug after 14 years of HPPC :)

This PR also adds more tests, making the randomized test against JDK HashMap run even for primitive keys/values (that revealed the small bug).