### PR TITLE
Add KTypeIndexedContainer stream, sort and reverse methods.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@
 
 ** New features and API changes
 
+   GH-250: Add KTypeIndexedContainer stream, sort and reverse methods. (Bruno Roustant)
+
    GH-247: Add KTypeArrayList removeAt and rename remove to removeElement. (Bruno Roustant)
 
    GH-244: Hide RamUsageEstimator from the public API. (Dawid Weiss)

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayList.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayList.java
@@ -504,6 +504,28 @@ public class KTypeArrayList<KType>
   #end !*/
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  public KTypeIndexedContainer<KType> sort() {
+    Arrays.sort(buffer, 0, elementsCount);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public KTypeIndexedContainer<KType> reverse() {
+    for (int i = 0, mid = elementsCount >> 1, j = elementsCount - 1; i < mid; i++, j--) {
+      KType tmp = Intrinsics.<KType> cast(buffer[i]);
+      buffer[i] = buffer[j];
+      buffer[j] = tmp;
+    }
+    return this;
+  }
+
+  /**
    * Clone this object. The returned clone will reuse the same hash function and
    * array resizing strategy.
    */

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayList.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeArrayList.java
@@ -1,6 +1,18 @@
 package com.carrotsearch.hppc;
 
 import java.util.*;
+/* #if ($TemplateOptions.KTypeGeneric) */
+import java.util.stream.Stream;
+/* #end */
+/*! #if ($TemplateOptions.isKTypeAnyOf("INT"))
+import java.util.stream.IntStream;
+#end !*/
+/*! #if ($TemplateOptions.isKTypeAnyOf("LONG"))
+import java.util.stream.LongStream;
+#end !*/
+/*! #if ($TemplateOptions.isKTypeAnyOf("DOUBLE"))
+import java.util.stream.DoubleStream;
+#end !*/
 
 import com.carrotsearch.hppc.cursors.*;
 import com.carrotsearch.hppc.predicates.KTypePredicate;
@@ -463,6 +475,33 @@ public class KTypeArrayList<KType>
   {
     return Arrays.copyOf(buffer, elementsCount);
   }
+
+  /* #if ($TemplateOptions.KTypeGeneric) */
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @SuppressWarnings("unchecked")
+  public Stream<KType> stream() {
+    return (Stream<KType>) Arrays.stream(buffer, 0, size());
+  }
+  /* #end */
+  /*! #if ($TemplateOptions.isKTypeAnyOf("INT"))
+  @Override
+  public IntStream stream() {
+  #end !*/
+  /*! #if ($TemplateOptions.isKTypeAnyOf("LONG"))
+  @Override
+  public LongStream stream() {
+  #end !*/
+  /*! #if ($TemplateOptions.isKTypeAnyOf("DOUBLE"))
+  @Override
+  public DoubleStream stream() {
+  #end !*/
+  /*! #if ($TemplateOptions.isKTypeAnyOf("INT", "LONG", "DOUBLE"))
+    return Arrays.stream(buffer, 0, size());
+  }
+  #end !*/
 
   /**
    * Clone this object. The returned clone will reuse the same hash function and

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeIndexedContainer.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeIndexedContainer.java
@@ -109,4 +109,14 @@ public interface KTypeIndexedContainer<KType> extends KTypeCollection<KType>, Ra
   /*! #if ($TemplateOptions.isKTypeAnyOf("INT")) public IntStream stream(); #end !*/
   /*! #if ($TemplateOptions.isKTypeAnyOf("LONG")) public LongStream stream(); #end !*/
   /*! #if ($TemplateOptions.isKTypeAnyOf("DOUBLE")) public DoubleStream stream(); #end !*/
+
+  /**
+   * Sorts the elements in this container and returns this container.
+   */
+  public KTypeIndexedContainer<KType> sort();
+
+  /**
+   * Reverses the elements in this container and returns this container.
+   */
+  public KTypeIndexedContainer<KType> reverse();
 }

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeIndexedContainer.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeIndexedContainer.java
@@ -1,6 +1,18 @@
 package com.carrotsearch.hppc;
 
 import java.util.RandomAccess;
+/* #if ($TemplateOptions.KTypeGeneric) */
+import java.util.stream.Stream;
+/* #end */
+/*! #if ($TemplateOptions.isKTypeAnyOf("INT"))
+import java.util.stream.IntStream;
+#end !*/
+/*! #if ($TemplateOptions.isKTypeAnyOf("LONG"))
+import java.util.stream.LongStream;
+#end !*/
+/*! #if ($TemplateOptions.isKTypeAnyOf("DOUBLE"))
+import java.util.stream.DoubleStream;
+#end !*/
 
 /**
  * An indexed container provides random access to elements based on an
@@ -87,4 +99,14 @@ public interface KTypeIndexedContainer<KType> extends KTypeCollection<KType>, Ra
    * <code>fromIndex</code>, inclusive, and <code>toIndex</code>, exclusive.
    */
   public void removeRange(int fromIndex, int toIndex);
+
+  /**
+   * Returns this container elements as a stream.
+   */
+  /* #if ($TemplateOptions.KTypeGeneric) */
+  public Stream<KType> stream();
+  /* #end */
+  /*! #if ($TemplateOptions.isKTypeAnyOf("INT")) public IntStream stream(); #end !*/
+  /*! #if ($TemplateOptions.isKTypeAnyOf("LONG")) public LongStream stream(); #end !*/
+  /*! #if ($TemplateOptions.isKTypeAnyOf("DOUBLE")) public DoubleStream stream(); #end !*/
 }

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeArrayListTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeArrayListTest.java
@@ -614,6 +614,33 @@ public class KTypeArrayListTest<KType> extends AbstractKTypeTest<KType>
     }
     /*! #end !*/
 
+    @Test
+    public void testSort() {
+        list = KTypeArrayList.from(key3, key1, key3, key2);
+        KTypeArrayList<KType> list2 = new KTypeArrayList<KType>();
+        list2.ensureCapacity(30);
+        list2.addAll(list);
+        assertSame(list2, list2.sort());
+        assertEquals2(KTypeArrayList.from(key1, key2, key3, key3), list2);
+    }
+
+    @Test
+    public void testReverse() {
+        for (int size = 0; size < 10; size++) {
+            KTypeArrayList<KType> list = new KTypeArrayList<KType>();
+            list.ensureCapacity(30);
+            for (int j = 0; j < size; j++) {
+                list.add(cast(j));
+            }
+            assertSame(list, list.reverse());
+            assertEquals(size, list.size());
+            int reverseIndex = size - 1;
+            for (KTypeCursor<KType> cursor : list) {
+                assertEquals2(cast(reverseIndex--), cursor.value);
+            }
+        }
+    }
+
     /* */
     @Test
     public void testClone()

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeArrayListTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeArrayListTest.java
@@ -599,9 +599,18 @@ public class KTypeArrayListTest<KType> extends AbstractKTypeTest<KType>
     @Test
     public void testToArray()
     {
-        KTypeArrayList<KType> l1 = KTypeArrayList.from(k1, k2, k3);
-        Object[] result = l1.toArray();
+        list = KTypeArrayList.from(k1, k2, k3);
+        Object[] result = list.toArray();
         assertArrayEquals(new Object [] {k1, k2, k3}, result);
+    }
+    /*! #end !*/
+
+    /*! #if ($TemplateOptions.isKTypeAnyOf("GENERIC", "INT", "LONG", "DOUBLE")) !*/
+    @Test
+    public void testStream() {
+        list.add(k1, k2, k3);
+        assertEquals2(k1, list.stream().findFirst().orElseThrow());
+        assertEquals2(k2, list.stream().toArray()[1]);
     }
     /*! #end !*/
 


### PR DESCRIPTION
The stream method  is generated for generic, int, long and double, as there are no other primitive streams.
It is only available in KTypeIndexedContainer, and not Container, because the iteration of the stream would need to be randomized for hash set and hash map. I'm not sure it is possible, anyway out of scope of this PR.

The sort and reverse methods return the indexed container itself, to be able to chain calls. Let me know if it is not intuitive.