### PR TITLE
Fix BitSet LookupContainer contains() to return false for negatives

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,11 @@
 
    GH-255: Minimum Java bumped to 21 (from 11). (Dawid Weiss)
 
+** Bugs
+
+   GH-257: BitSet.asIntLookupContainer()/asLongLookupContainer().contains() now
+   returns false (not true) for negative indices. (raphaelroshan)
+
 [0.10.0]
 
 ** New features and API changes

--- a/hppc/src/main/java/com/carrotsearch/hppc/BitSet.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/BitSet.java
@@ -835,7 +835,7 @@ public class BitSet implements Cloneable {
 
       @Override
       public boolean contains(int index) {
-        return index < 0 || BitSet.this.get(index);
+        return index >= 0 && BitSet.this.get(index);
       }
 
       /**
@@ -933,7 +933,7 @@ public class BitSet implements Cloneable {
 
       @Override
       public boolean contains(long index) {
-        return index < 0 || BitSet.this.get(index);
+        return index >= 0 && BitSet.this.get(index);
       }
 
       /**

--- a/hppc/src/test/java/com/carrotsearch/hppc/BitSetTest.java
+++ b/hppc/src/test/java/com/carrotsearch/hppc/BitSetTest.java
@@ -153,8 +153,9 @@ public class BitSetTest extends RandomizedTest {
       assertEquals(hppc.get(i), ilc.contains(i));
     }
 
-    // IntLookupContainer must not throw exceptions on negative arguments.
-    ilc.contains(-1);
+    // IntLookupContainer must return false, not throw, on negative arguments.
+    assertFalse(ilc.contains(-1));
+    assertFalse(ilc.contains(Integer.MIN_VALUE));
   }
 
   private void assertLongLookupContainer(final java.util.BitSet jre, LongLookupContainer llc) {
@@ -207,7 +208,8 @@ public class BitSetTest extends RandomizedTest {
       assertEquals(hppc.get(i), llc.contains(i));
     }
 
-    // IntLookupContainer must not throw exceptions on negative arguments.
-    llc.contains(-1);
+    // LongLookupContainer must return false, not throw, on negative arguments.
+    assertFalse(llc.contains(-1));
+    assertFalse(llc.contains(Long.MIN_VALUE));
   }
 }


### PR DESCRIPTION
`BitSet.asIntLookupContainer()` and `asLongLookupContainer()` returned `true` from `contains()` for negative indices. The `index < 0 ||` short-circuit was there only to avoid an AIOOBE in `get(int)`, but a `BitSet` never contains a negative index, so the correct result is `false` — returning `true` misreports out-of-domain keys to `LookupContainer` consumers such as `retainAll`/`removeAll`.

Return `false` for negatives while still guarding the array access, and strengthen the existing tests to assert the value.