### PR TITLE
RamUsageEstimator: Account for compressed class pointers & compact object headers (if enabled)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ carrotsearch-console-launcher = { module = "com.carrotsearch.console:launcher", 
 commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
 fastutil = { module = "it.unimi.dsi:fastutil", version.ref = "fastutil" }
 # @keep This is used in publishing/maven.gradle
-httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version = "5.6.2" }
+httpclient5 = "org.apache.httpcomponents.client5:httpclient5:5.6.2"
 # @keep This is used in gitinfo.gradle
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }

--- a/hppc/src/main/java/com/carrotsearch/hppc/RamUsageEstimator.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/RamUsageEstimator.java
@@ -16,7 +16,10 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 /**
- * Helper class that helps estimate memory usage
+ * Helper class that helps estimate memory usage.
+ *
+ * <p>If you're looking for something more in-depth, check out the <a
+ * href="https://github.com/openjdk/jol">jol</a> project.
  *
  * <p>Mostly forked from Lucene tag releases/lucene-solr/8.5.1
  */
@@ -149,8 +152,7 @@ final class RamUsageEstimator {
       NUM_BYTES_OBJECT_HEADER =
           COMPACT_OBJECT_HEADERS_ENABLED
               ? Long.BYTES
-              : Long.BYTES
-                  + (COMPRESSED_CLASS_POINTERS_ENABLED ? Integer.BYTES : Long.BYTES);
+              : Long.BYTES + (COMPRESSED_CLASS_POINTERS_ENABLED ? Integer.BYTES : Long.BYTES);
       // Keep the raw header unaligned; alignment belongs after the array payload.
       NUM_BYTES_ARRAY_HEADER = NUM_BYTES_OBJECT_HEADER + Integer.BYTES;
     } else {

--- a/hppc/src/main/java/com/carrotsearch/hppc/RamUsageEstimator.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/RamUsageEstimator.java
@@ -27,13 +27,19 @@ final class RamUsageEstimator {
   /** True, iff compressed references (oops) are enabled by this JVM */
   static final boolean COMPRESSED_REFS_ENABLED;
 
+  /** True, iff compressed class pointers are enabled by this JVM. */
+  static final boolean COMPRESSED_CLASS_POINTERS_ENABLED;
+
+  /** True, iff compact object headers are enabled by this JVM. */
+  static final boolean COMPACT_OBJECT_HEADERS_ENABLED;
+
   /** Number of bytes this JVM uses to represent an object reference. */
   static final int NUM_BYTES_OBJECT_REF;
 
   /** Number of bytes to represent an object header (no fields, no alignments). */
   static final int NUM_BYTES_OBJECT_HEADER;
 
-  /** Number of bytes to represent an array header (no content, but with alignments). */
+  /** Number of bytes to represent an unaligned array header (no content). */
   static final int NUM_BYTES_ARRAY_HEADER;
 
   /**
@@ -82,9 +88,11 @@ final class RamUsageEstimator {
     }
     JRE_IS_64BIT = is64Bit;
     if (JRE_IS_64BIT) {
-      // Try to get compressed oops and object alignment (the default seems to be 8 on Hotspot);
-      // (this only works on 64 bit, on 32 bits the alignment and reference size is fixed):
+      // Try to get compressed oops, compressed class pointers, compact headers, and object
+      // alignment (the default seems to be 8 on Hotspot).
       boolean compressedOops = false;
+      boolean compressedClassPointers = false;
+      boolean compactObjectHeaders = false;
       int objectAlignment = 8;
       try {
         final Class<?> beanClazz = Class.forName(HOTSPOT_BEAN_CLASS);
@@ -101,6 +109,24 @@ final class RamUsageEstimator {
             compressedOops =
                 Boolean.parseBoolean(
                     vmOption.getClass().getMethod("getValue").invoke(vmOption).toString());
+            // Preserve the previous oop-width assumption if the class-pointer option cannot be read.
+            compressedClassPointers = compressedOops;
+          } catch (ReflectiveOperationException | RuntimeException ignored) {
+          }
+          try {
+            final Object vmOption =
+                getVMOptionMethod.invoke(hotSpotBean, "UseCompressedClassPointers");
+            compressedClassPointers =
+                Boolean.parseBoolean(
+                    vmOption.getClass().getMethod("getValue").invoke(vmOption).toString());
+          } catch (ReflectiveOperationException | RuntimeException ignored) {
+          }
+          try {
+            final Object vmOption =
+                getVMOptionMethod.invoke(hotSpotBean, "UseCompactObjectHeaders");
+            compactObjectHeaders =
+                Boolean.parseBoolean(
+                    vmOption.getClass().getMethod("getValue").invoke(vmOption).toString());
           } catch (ReflectiveOperationException | RuntimeException ignored) {
           }
           try {
@@ -114,15 +140,24 @@ final class RamUsageEstimator {
       } catch (ReflectiveOperationException | RuntimeException ignored) {
       }
       COMPRESSED_REFS_ENABLED = compressedOops;
+      COMPRESSED_CLASS_POINTERS_ENABLED = compressedClassPointers;
+      COMPACT_OBJECT_HEADERS_ENABLED = compactObjectHeaders;
       NUM_BYTES_OBJECT_ALIGNMENT = objectAlignment;
       // reference size is 4, if we have compressed oops:
       NUM_BYTES_OBJECT_REF = COMPRESSED_REFS_ENABLED ? 4 : 8;
-      // "best guess" based on reference size:
-      NUM_BYTES_OBJECT_HEADER = 8 + NUM_BYTES_OBJECT_REF;
-      // array header is NUM_BYTES_OBJECT_HEADER + NUM_BYTES_INT, but aligned (object alignment):
-      NUM_BYTES_ARRAY_HEADER = (int) alignObjectSize(NUM_BYTES_OBJECT_HEADER + Integer.BYTES);
+      // Compact headers combine mark and class information. Without them, the class-pointer width
+      // is independent of the ordinary object-reference width.
+      NUM_BYTES_OBJECT_HEADER =
+          COMPACT_OBJECT_HEADERS_ENABLED
+              ? Long.BYTES
+              : Long.BYTES
+                  + (COMPRESSED_CLASS_POINTERS_ENABLED ? Integer.BYTES : Long.BYTES);
+      // Keep the raw header unaligned; alignment belongs after the array payload.
+      NUM_BYTES_ARRAY_HEADER = NUM_BYTES_OBJECT_HEADER + Integer.BYTES;
     } else {
       COMPRESSED_REFS_ENABLED = false;
+      COMPRESSED_CLASS_POINTERS_ENABLED = false;
+      COMPACT_OBJECT_HEADERS_ENABLED = false;
       NUM_BYTES_OBJECT_ALIGNMENT = 8;
       NUM_BYTES_OBJECT_REF = 4;
       NUM_BYTES_OBJECT_HEADER = 8;

--- a/hppc/src/main/java/com/carrotsearch/hppc/RamUsageEstimator.java
+++ b/hppc/src/main/java/com/carrotsearch/hppc/RamUsageEstimator.java
@@ -109,8 +109,6 @@ final class RamUsageEstimator {
             compressedOops =
                 Boolean.parseBoolean(
                     vmOption.getClass().getMethod("getValue").invoke(vmOption).toString());
-            // Preserve the previous oop-width assumption if the class-pointer option cannot be read.
-            compressedClassPointers = compressedOops;
           } catch (ReflectiveOperationException | RuntimeException ignored) {
           }
           try {
@@ -146,7 +144,8 @@ final class RamUsageEstimator {
       // reference size is 4, if we have compressed oops:
       NUM_BYTES_OBJECT_REF = COMPRESSED_REFS_ENABLED ? 4 : 8;
       // Compact headers combine mark and class information. Without them, the class-pointer width
-      // is independent of the ordinary object-reference width.
+      // is independent of the ordinary object-reference width:
+      // See https://openjdk.org/jeps/450 for visual explanation.
       NUM_BYTES_OBJECT_HEADER =
           COMPACT_OBJECT_HEADERS_ENABLED
               ? Long.BYTES


### PR DESCRIPTION
Fixes https://github.com/carrotsearch/hppc/issues/259

## Summary

- Fix `RamUsageEstimator` so object/array header sizes match modern HotSpot layouts.
- Read `UseCompressedClassPointers` and `UseCompactObjectHeaders` (same MXBean path as existing UseCompressedOops).
- Stop assuming the class pointer has the same width as a normal object reference.
- Keep array headers unaligned until after the payload is added (avoids over-counting some arrays with compact headers).

## Validation

Checked locally on Amazon Corretto 25.0.3 / AArch64 with JOL and `Instrumentation.getObjectSize()`:

| Heap / layout | Compact object headers | Compressed object pointers (oops) | Object header (bytes) | Array header (bytes) | Object reference (bytes) |
|---|---|---|---|---|---|
| 40 GiB, legacy headers | no | no | 12 | 16 | 8 |
| 40 GiB, compact headers | yes | no | 8 | 12 | 8 |
| 4 GiB, legacy headers | no | yes | 12 | 16 | 4 |
| 4 GiB, compact headers | yes | yes | 8 | 12 | 4 |

Explanation:
* **40 GiB / 4 GiB:** Heap size used in the check. Above 32 GiB, HotSpot disables compressed oops, so references are 8 bytes. Class pointers can still stay 4 bytes (`UseCompressedClassPointers`, independent since JDK 15)
* **Legacy / compact:** Legacy = 8-byte mark word + separate class word (usually 4 bytes → 12-byte header). Compact = class pointer folded into the mark word → 8-byte header
* **Compact object headers:** Is the new smaller header layout on? The class pointer lives inside the 8-byte mark word (`UseCompactObjectHeaders`)
* **Compressed object pointers (oops):** Are normal Java object references stored as 4 bytes instead of 8? (`UseCompressedOops`)
* **Object header size:** Bytes for a plain object header (before fields / alignment)
* **Array header size:** Object header + 4-byte array length (before elements / alignment)
* **Object reference size:** Bytes for one ordinary object reference / oop


---
AI disclosure: Findings were validated with AI & AI helped writing the PR