### PR TITLE
Fix KTypePgmIndex.indexOf forward scan reading one past the last key

### DIFF
--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypePgmIndex.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypePgmIndex.java
@@ -201,13 +201,13 @@ public class KTypePgmIndex<KType> implements Accountable {
       // Continue scanning out of the epsilon range.
       int jump = BEYOND_EPSILON_JUMP;
       do {
-        int hiIndex = Math.min(index + jump, keys.size());
+        int hiIndex = Math.min(index + jump, keys.size() - 1);
         if (Intrinsics.<KType>numeric(key) <= Intrinsics.<KType>numeric(keys.get(hiIndex))) {
-          return Arrays.binarySearch(keys.buffer, index, hiIndex, key);
+          return Arrays.binarySearch(keys.buffer, index, hiIndex + 1, key);
         }
         index = hiIndex;
         jump <<= 1;
-      } while (index < keys.size());
+      } while (index < keys.size() - 1);
       return -keys.size() - 1;
     }
   }

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypePgmIndexTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypePgmIndexTest.java
@@ -193,4 +193,65 @@ public class KTypePgmIndexTest<KType> extends AbstractKTypeTest<KType> {
       System.out.println("builder.ramBytesAllocated() = " + builder.ramBytesAllocated() + " B");
     }
   }
+
+  /*! #if ($TemplateOptions.KTypeGeneric) !*/ @Disabled /*! #end !*/
+  @Test
+  public void testIndexOfLargeLastKey() {
+    // A dense run followed by a large outlier as the last key forces the
+    // beyond-epsilon forward scan to reach the array end.
+    KType maxKey = Intrinsics.<KType>cast(
+      /*! #if ($TemplateOptions.isKTypeAnyOf("INT")) !*/ Integer.MAX_VALUE /*! #end !*/
+      /*! #if ($TemplateOptions.isKTypeAnyOf("LONG")) Long.MAX_VALUE #end !*/
+      /*! #if ($TemplateOptions.isKTypeAnyOf("FLOAT")) Float.MAX_VALUE #end !*/
+      /*! #if ($TemplateOptions.isKTypeAnyOf("DOUBLE")) Double.MAX_VALUE #end !*/
+    );
+    KType[] keys = newArray(cast(0), cast(1), cast(2), cast(3), maxKey);
+    // Both a slack-backed list and an exactly-sized buffer must locate the key.
+    assertLocatesLargeLastKey(
+      new KTypePgmIndex.KTypeBuilder<KType>()
+        .setSortedKeys(KTypeArrayList.from(keys)).setEpsilon(1).build(), maxKey);
+    assertLocatesLargeLastKey(
+      new KTypePgmIndex.KTypeBuilder<KType>()
+        .setSortedKeys(keys, keys.length).setEpsilon(1).build(), maxKey);
+  }
+
+  private void assertLocatesLargeLastKey(KTypePgmIndex<KType> pgmIndex, KType maxKey) {
+    assertEquals(4, pgmIndex.indexOf(maxKey));
+    assertTrue(pgmIndex.contains(maxKey));
+    assertEquals(4, pgmIndex.rank(maxKey));
+    // No regression: an absent key above the dense run keeps the right insertion point.
+    assertEquals(-5, pgmIndex.indexOf(cast(4)));
+    assertFalse(pgmIndex.contains(cast(4)));
+  }
+
+  /*! #if ($TemplateOptions.KTypeGeneric) !*/ @Disabled /*! #end !*/
+  @Test
+  public void testIndexOfDifferentialLargeTail() {
+    // Differential oracle: indexOf must equal Arrays.binarySearch for every key.
+    KType maxKey = Intrinsics.<KType>cast(
+      /*! #if ($TemplateOptions.isKTypeAnyOf("INT")) !*/ Integer.MAX_VALUE /*! #end !*/
+      /*! #if ($TemplateOptions.isKTypeAnyOf("LONG")) Long.MAX_VALUE #end !*/
+      /*! #if ($TemplateOptions.isKTypeAnyOf("FLOAT")) Float.MAX_VALUE #end !*/
+      /*! #if ($TemplateOptions.isKTypeAnyOf("DOUBLE")) Double.MAX_VALUE #end !*/
+    );
+    int n = 500;
+    KType[] keys = Intrinsics.<KType>newArray(n);
+    for (int i = 0; i < n - 1; i++) {
+      keys[i] = cast(i);
+    }
+    keys[n - 1] = maxKey;
+    for (int epsilon : new int[] {1, 4, 64}) {
+      KTypePgmIndex<KType> pgmIndex = new KTypePgmIndex.KTypeBuilder<KType>()
+        .setSortedKeys(keys, keys.length).setEpsilon(epsilon).build();
+      for (int i = 0; i < n; i++) {
+        assertEquals(Arrays.binarySearch(keys, keys[i]), pgmIndex.indexOf(keys[i]),
+          "epsilon=" + epsilon + " key=" + keys[i]);
+      }
+      // Absent keys map to the same negative insertion point as the oracle.
+      for (KType probe : newArray(cast(-1), cast(n))) {
+        assertEquals(Arrays.binarySearch(keys, probe), pgmIndex.indexOf(probe),
+          "epsilon=" + epsilon + " probe=" + probe);
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Problem

`KTypePgmIndex.indexOf` can fail to locate a key that is present, and can throw
`ArrayIndexOutOfBoundsException`, when the search falls into the beyond-epsilon
forward scan and that scan runs to the end of the key array.

The forward loop clamps the probe index to `keys.size()` and then dereferences it:

```java
int hiIndex = Math.min(index + jump, keys.size());   // can equal size()
if (numeric(key) <= numeric(keys.get(hiIndex))) {     // keys.get(size) -> out of bounds
```

`keys.get(size)` is one past the last valid index (`size - 1`):

- with a slack-backed `KTypeArrayList`, it reads the default slot, so a large last
  key compares as "not present" and `indexOf` silently returns `-size - 1`;
- with an exactly-sized buffer (`setSortedKeys(array, length)`), it throws AIOOBE.

Since `indexOf` returns early when `key > lastKey`, in this branch `key <= lastKey`
always holds, so the present key is missed. `contains`, `rank`, `rangeCardinality`,
`rangeIterator` and `forEachInRange` all route through `indexOf` and inherit it.

Minimal repro (`{0, 1, 2, 3, MAX_VALUE}`, epsilon 1): `indexOf(MAX_VALUE)` returns
`-6` instead of `4`, `contains(MAX_VALUE)` is `false`. Reproduces for Int, Long and
Double; Float shares the code path (its approximation happens to land inside the
epsilon window for this input, so it is latent there).

### Fix

The backward beyond-epsilon scan in the same method is already correct: it clamps
with `Math.max(index - jump, 0)`, always in bounds, and its `binarySearch` lower
bound is inclusive. Mirror it in the forward direction: clamp `hiIndex` to
`keys.size() - 1` and make that last slot inclusive in the `binarySearch` upper
bound (`hiIndex + 1`). One template change, so all four generated specializations
are fixed together.

### Tests

Added to `KTypePgmIndexTest` (generated for Int/Long/Float/Double):

- `testIndexOfLargeLastKey` - a dense run plus a large outlier as the last key,
  asserting `indexOf`/`contains`/`rank` locate it, for both a slack list and an
  exactly-sized buffer, plus the absent-key insertion point.
- `testIndexOfDifferentialLargeTail` - a differential check of `indexOf` against
  `Arrays.binarySearch` over the whole array (present and absent keys, epsilon
  1/4/64), which the Javadoc contract says must agree.

Both fail on the current code (silent miss and AIOOBE) and pass with the fix.
`./gradlew check` is green (JDK 25).
